### PR TITLE
Prepare for additional sensors

### DIFF
--- a/custom_components/aguaiot/climate.py
+++ b/custom_components/aguaiot/climate.py
@@ -98,7 +98,14 @@ class AguaIOTHeatingDevice(AguaIOTClimateDevice):
                 f"temp_{variant}_get" in self._device.registers
                 and self._device.get_register_value(f"temp_{variant}_get")
             ):
-                self._device_type = variant
+                self._temperature_get_key = f"temp_{variant}_get"
+
+        for variant in DEVICE_VARIANTS:
+            if (
+                f"temp_{variant}_set" in self._device.registers
+                and self._device.get_register_value(f"temp_{variant}_set")
+            ):
+                self._temperature_set_key = f"temp_{variant}_set"
 
     @property
     def unique_id(self):
@@ -195,22 +202,22 @@ class AguaIOTHeatingDevice(AguaIOTClimateDevice):
     @property
     def min_temp(self):
         """Return the minimum temperature to set."""
-        return self._device.get_register_value_min(f"temp_{self._device_type}_set")
+        return self._device.get_register_value_min(self._temperature_set_key)
 
     @property
     def max_temp(self):
         """Return the maximum temperature to set."""
-        return self._device.get_register_value_max(f"temp_{self._device_type}_set")
+        return self._device.get_register_value_max(self._temperature_set_key)
 
     @property
     def current_temperature(self):
         """Return the current temperature."""
-        return self._device.get_register_value(f"temp_{self._device_type}_get")
+        return self._device.get_register_value(self._temperature_get_key)
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self._device.get_register_value(f"temp_{self._device_type}_set")
+        return self._device.get_register_value(self._temperature_set_key)
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
@@ -220,7 +227,7 @@ class AguaIOTHeatingDevice(AguaIOTClimateDevice):
 
         try:
             await self._device.set_register_value(
-                f"temp_{self._device_type}_set", temperature
+                self._temperature_set_key, temperature
             )
             await self.coordinator.async_request_refresh()
         except (ValueError, AguaIOTError) as err:

--- a/custom_components/aguaiot/const.py
+++ b/custom_components/aguaiot/const.py
@@ -18,6 +18,8 @@ from homeassistant.components.number import (
     NumberEntityDescription,
 )
 
+from dataclasses import dataclass
+
 DOMAIN = "aguaiot"
 CONF_API_URL = "api_url"
 CONF_BRAND_ID = "brand_id"
@@ -45,40 +47,61 @@ PLATFORMS = [
 
 UPDATE_INTERVAL = 60
 
+
+@dataclass
+class AguaIotSensorEntityDescription(SensorEntityDescription):
+    enable_key: str | None = None
+
+
+@dataclass
+class AguaIotSwitchEntityDescription(SwitchEntityDescription):
+    enable_key: str | None = None
+
+
+@dataclass
+class AguaIotNumberEntityDescription(NumberEntityDescription):
+    enable_key: str | None = None
+
+
 SENSORS = (
-    SensorEntityDescription(
+    AguaIotSensorEntityDescription(
         key="temp_gas_flue_get",
         name="Smoke Temperature",
+        enable_key=None,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
-    SensorEntityDescription(
+    AguaIotSensorEntityDescription(
         key="temp_probe_k_get",
         name="Flame Temperature",
+        enable_key=None,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
     ),
-    SensorEntityDescription(
+    AguaIotSensorEntityDescription(
         key="status_get",
         name="Status",
+        enable_key=None,
         icon="mdi:fire",
         native_unit_of_measurement=None,
         state_class=None,
         device_class=None,
     ),
-    SensorEntityDescription(
+    AguaIotSensorEntityDescription(
         key="alarms_get",
         name="Alarm",
+        enable_key=None,
         icon="mdi:alert-outline",
         native_unit_of_measurement=None,
         state_class=None,
         device_class=None,
     ),
-    SensorEntityDescription(
+    AguaIotSensorEntityDescription(
         key="real_power_get",
         name="Real Power",
+        enable_key="real_power_enable",
         icon="mdi:gauge",
         native_unit_of_measurement=None,
         state_class=None,
@@ -87,31 +110,35 @@ SENSORS = (
 )
 
 SWITCHES = (
-    SwitchEntityDescription(
+    AguaIotSwitchEntityDescription(
         key="natural_mode",
         name="Natural Mode",
+        enable_key=None,
         icon="mdi:fan-off",
         device_class=SwitchDeviceClass.SWITCH,
     ),
-    SwitchEntityDescription(
+    AguaIotSwitchEntityDescription(
         key="standby_set",
         name="Standby",
+        enable_key=None,
         icon="mdi:power-standby",
         device_class=SwitchDeviceClass.SWITCH,
     ),
 )
 
 NUMBERS = (
-    NumberEntityDescription(
+    AguaIotNumberEntityDescription(
         key="energy_saving_air_start",
         name="Energy Saving Start",
+        enable_key=None,
         native_step=1,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=NumberDeviceClass.TEMPERATURE,
     ),
-    NumberEntityDescription(
+    AguaIotNumberEntityDescription(
         key="energy_saving_air_stop",
         name="Energy Saving Stop",
+        enable_key=None,
         native_step=1,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=NumberDeviceClass.TEMPERATURE,

--- a/custom_components/aguaiot/const.py
+++ b/custom_components/aguaiot/const.py
@@ -55,7 +55,7 @@ SENSORS = (
     ),
     SensorEntityDescription(
         key="temp_probe_k_get",
-        name="Smoke Temperature",
+        name="Flame Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,

--- a/custom_components/aguaiot/number.py
+++ b/custom_components/aguaiot/number.py
@@ -22,7 +22,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for device in agua.devices:
         for number in NUMBERS:
             if number.key in device.registers:
-                numbers.append(AguaIOTHeatingNumber(coordinator, device, number))
+                if number.enable_key is None:
+                    numbers.append(AguaIOTHeatingNumber(coordinator, device, number))
+                elif device.get_register_value(number.enable_key) == 1:
+                    numbers.append(AguaIOTHeatingNumber(coordinator, device, number))
 
     async_add_entities(numbers, True)
 

--- a/custom_components/aguaiot/number.py
+++ b/custom_components/aguaiot/number.py
@@ -24,7 +24,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
             if number.key in device.registers:
                 if number.enable_key is None:
                     numbers.append(AguaIOTHeatingNumber(coordinator, device, number))
-                elif device.get_register_value(number.enable_key) == 1:
+                elif number.enable_key in device.registers:
+                    if device.get_register_value(number.enable_key) == 1:
+                        numbers.append(
+                            AguaIOTHeatingNumber(coordinator, device, number)
+                        )
+                else:
                     numbers.append(AguaIOTHeatingNumber(coordinator, device, number))
 
     async_add_entities(numbers, True)

--- a/custom_components/aguaiot/sensor.py
+++ b/custom_components/aguaiot/sensor.py
@@ -19,8 +19,14 @@ async def async_setup_entry(hass, entry, async_add_entities):
             if sensor.key in device.registers:
                 if sensor.enable_key is None:
                     sensors.append(AguaIOTHeatingSensor(coordinator, device, sensor))
-                elif device.get_register_value(sensor.enable_key) == 1:
+                elif sensor.enable_key in device.registers:
+                    if device.get_register_value(sensor.enable_key) == 1:
+                        sensors.append(
+                            AguaIOTHeatingSensor(coordinator, device, sensor)
+                        )
+                else:
                     sensors.append(AguaIOTHeatingSensor(coordinator, device, sensor))
+
     async_add_entities(sensors, True)
 
 

--- a/custom_components/aguaiot/sensor.py
+++ b/custom_components/aguaiot/sensor.py
@@ -17,8 +17,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for device in agua.devices:
         for sensor in SENSORS:
             if sensor.key in device.registers:
-                sensors.append(AguaIOTHeatingSensor(coordinator, device, sensor))
-
+                if sensor.enable_key is None:
+                    sensors.append(AguaIOTHeatingSensor(coordinator, device, sensor))
+                elif device.get_register_value(sensor.enable_key) == 1:
+                    sensors.append(AguaIOTHeatingSensor(coordinator, device, sensor))
     async_add_entities(sensors, True)
 
 

--- a/custom_components/aguaiot/switch.py
+++ b/custom_components/aguaiot/switch.py
@@ -22,7 +22,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     for device in agua.devices:
         for switch in SWITCHES:
             if switch.key in device.registers:
-                switches.append(AguaIOTHeatingSwitch(coordinator, device, switch))
+                if switch.enable_key is None:
+                    switches.append(AguaIOTHeatingSwitch(coordinator, device, switch))
+                elif device.get_register_value(switch.enable_key) == 1:
+                    switches.append(AguaIOTHeatingSwitch(coordinator, device, switch))
 
     async_add_entities(switches, True)
 

--- a/custom_components/aguaiot/switch.py
+++ b/custom_components/aguaiot/switch.py
@@ -24,7 +24,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
             if switch.key in device.registers:
                 if switch.enable_key is None:
                     switches.append(AguaIOTHeatingSwitch(coordinator, device, switch))
-                elif device.get_register_value(switch.enable_key) == 1:
+                elif switch.enable_key in device.registers:
+                    if device.get_register_value(switch.enable_key) == 1:
+                        switches.append(
+                            AguaIOTHeatingSwitch(coordinator, device, switch)
+                        )
+                else:
                     switches.append(AguaIOTHeatingSwitch(coordinator, device, switch))
 
     async_add_entities(switches, True)


### PR DESCRIPTION
Add usage of "ENABLE" type refgisters to check if a register is in used by the stove model (and not only a "brand generic register".
Helpfull to not create sensor and other entities not available on the stove.