### PR TITLE
Dynamically adjust climate entity to stove mode when having a hybrid stove

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test.py
 .vscode
 venv/
 mocks/
+aguaiot_debug.py

--- a/custom_components/aguaiot/binary_sensor.py
+++ b/custom_components/aguaiot/binary_sensor.py
@@ -15,9 +15,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     sensors = []
     for device in agua.devices:
+        hybrid = "power_wood_set" in device.registers
+
         for sensor in BINARY_SENSORS:
-            if sensor.key in device.registers and (
-                sensor.force_enabled or device.get_register_enabled(sensor.key)
+            if (
+                sensor.key in device.registers
+                and (sensor.force_enabled or device.get_register_enabled(sensor.key))
+                and (not sensor.hybrid_only or hybrid)
             ):
                 sensors.append(AguaIOTHeatingBinarySensor(coordinator, device, sensor))
 

--- a/custom_components/aguaiot/climate.py
+++ b/custom_components/aguaiot/climate.py
@@ -97,7 +97,7 @@ class AguaIOTHeatingDevice(AguaIOTClimateDevice):
         """Initialize the thermostat."""
         CoordinatorEntity.__init__(self, coordinator)
         self._device = device
-        self._hybrid = "power_wood_set" in self._device.registers
+        self._hybrid = "power_wood_set" in device.registers
 
         self._temperature_get_key = None
         for variant in DEVICE_VARIANTS:

--- a/custom_components/aguaiot/const.py
+++ b/custom_components/aguaiot/const.py
@@ -44,6 +44,8 @@ CONF_LOGIN_API_URL = "login_api_url"
 CONF_UUID = "uuid"
 
 DEVICE_VARIANTS = ["water", "air", "air2", "air_palm"]
+MODE_WOOD = "Wood"
+MODE_PELLETS = "Pellets"
 
 PLATFORMS = [
     Platform.CLIMATE,
@@ -151,16 +153,6 @@ NUMBERS = (
         native_step=1,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=NumberDeviceClass.TEMPERATURE,
-    ),
-    NumberEntityDescription(
-        key="power_set",
-        name="Pellet Power",
-        native_step=1,
-    ),
-    NumberEntityDescription(
-        key="power_wood_set",
-        name="Wood Power",
-        native_step=1,
     ),
 )
 

--- a/custom_components/aguaiot/const.py
+++ b/custom_components/aguaiot/const.py
@@ -30,11 +30,19 @@ from dataclasses import dataclass
 @dataclass
 class AguaIOTBinarySensorEntityDescription(BinarySensorEntityDescription):
     force_enabled: bool = False
+    hybrid_only: bool = False
 
 
 @dataclass
 class AguaIOTSensorEntityDescription(SensorEntityDescription):
     force_enabled: bool = False
+    hybrid_only: bool = False
+
+
+@dataclass
+class AguaIOTNumberEntityDescription(NumberEntityDescription):
+    force_enabled: bool = False
+    hybrid_only: bool = False
 
 
 DOMAIN = "aguaiot"
@@ -45,7 +53,7 @@ CONF_UUID = "uuid"
 
 DEVICE_VARIANTS = ["water", "air", "air2", "air_palm"]
 MODE_WOOD = "Wood"
-MODE_PELLETS = "Pellets"
+MODE_PELLETS = "Pellet"
 
 PLATFORMS = [
     Platform.CLIMATE,
@@ -121,6 +129,7 @@ SENSORS = (
         state_class=None,
         device_class=None,
         force_enabled=True,
+        hybrid_only=True,
     ),
 )
 
@@ -140,19 +149,31 @@ SWITCHES = (
 )
 
 NUMBERS = (
-    NumberEntityDescription(
+    AguaIOTNumberEntityDescription(
         key="es_air_start_set",
         name="Energy Saving Start",
         native_step=1,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=NumberDeviceClass.TEMPERATURE,
     ),
-    NumberEntityDescription(
+    AguaIOTNumberEntityDescription(
         key="es_air_stop_set",
         name="Energy Saving Stop",
         native_step=1,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=NumberDeviceClass.TEMPERATURE,
+    ),
+    AguaIOTNumberEntityDescription(
+        key="power_set",
+        name="Pellet Power",
+        native_step=1,
+        hybrid_only=True,
+    ),
+    AguaIOTNumberEntityDescription(
+        key="power_wood_set",
+        name="Wood Power",
+        native_step=1,
+        hybrid_only=True,
     ),
 )
 

--- a/custom_components/aguaiot/number.py
+++ b/custom_components/aguaiot/number.py
@@ -16,9 +16,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     numbers = []
     for device in agua.devices:
+        hybrid = "power_wood_set" in device.registers
+
         for number in NUMBERS:
-            if number.key in device.registers and device.get_register_enabled(
-                number.key
+            if (
+                number.key in device.registers
+                and (number.force_enabled or device.get_register_enabled(number.key))
+                and (not number.hybrid_only or hybrid)
             ):
                 numbers.append(AguaIOTHeatingNumber(coordinator, device, number))
 

--- a/custom_components/aguaiot/sensor.py
+++ b/custom_components/aguaiot/sensor.py
@@ -15,9 +15,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     sensors = []
     for device in agua.devices:
+        hybrid = "power_wood_set" in device.registers
+
         for sensor in SENSORS:
-            if sensor.key in device.registers and (
-                sensor.force_enabled or device.get_register_enabled(sensor.key)
+            if (
+                sensor.key in device.registers
+                and (sensor.force_enabled or device.get_register_enabled(sensor.key))
+                and (not sensor.hybrid_only or hybrid)
             ):
                 sensors.append(AguaIOTHeatingSensor(coordinator, device, sensor))
 


### PR DESCRIPTION
The climate entity now dynamically adjusts to the mode of the stove, and displays the current mode by using a preset. Please let me know what you think (and if it works correctly) @jipem01 