### PR TITLE
Changed timing of update http requests and add logging

### DIFF
--- a/custom_components/aguaiot/aguaiot.py
+++ b/custom_components/aguaiot/aguaiot.py
@@ -1,6 +1,7 @@
 """py_agua_iot provides controlling heating devices connected via
 the IOT Agua platform of Micronova
 """
+
 import asyncio
 import jwt
 import logging


### PR DESCRIPTION
Doing the first jobstatus query to quickly after posting the job caused us needing to do an additional retry. Waiting a bit saves us a request per update.