### PR TITLE
Add .devcontainer configuration for Github Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "postCreateCommand": "python .devcontainer/init.py",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "postCreateCommand": "python .devcontainer/init.py",
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "ms-python.python"
-      ]
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "postCreateCommand": "python .devcontainer/init.py",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python"
+            ]
+        }
     }
-  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "ms-python.python"
+                "ms-python.python",
+                "mikoz.black-py",
+                "github.vscode-github-actions"
             ]
         }
     }

--- a/.devcontainer/init.py
+++ b/.devcontainer/init.py
@@ -1,0 +1,15 @@
+"""
+Initialize container with modules used by volkswage_we_connect_id component
+"""
+
+import json
+import pip
+
+PIP_ARGUMENTS = [ "install", "--user", "homeassistant" ]
+MANIFEST_PATH = "custom_components/aguaiot/manifest.json"
+
+with open(MANIFEST_PATH, "r", encoding="utf8") as MANIFEST_FILE:
+    MANIFEST = json.load(MANIFEST_FILE)
+    REQUIREMENTS: list[str] = MANIFEST["requirements"]
+
+pip.main(PIP_ARGUMENTS + REQUIREMENTS)

--- a/.devcontainer/init.py
+++ b/.devcontainer/init.py
@@ -5,7 +5,7 @@ Initialize container with modules used by volkswage_we_connect_id component
 import json
 import pip
 
-PIP_ARGUMENTS = [ "install", "--user", "homeassistant" ]
+PIP_ARGUMENTS = ["install", "--user", "homeassistant", "black"]
 MANIFEST_PATH = "custom_components/aguaiot/manifest.json"
 
 with open(MANIFEST_PATH, "r", encoding="utf8") as MANIFEST_FILE:


### PR DESCRIPTION
Add a simple devcontainer.json to allow working on the repo from Github Codespaces.

Create a container with Python and a couple of other useful extensions:

* Black formatter
* Github actions

Calls a script on container creation to install homeassistant and black, as well as any packages defined in the extension manifest.