### PR TITLE
Add experimental local Bluetooth mode for Micronova stoves

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,67 @@ Or folow these steps:
 2. Install the plugin via HACS (Micronova Agua IOT)
 3. Add the integration through the home assistant configuration flow
 
+## Local Bluetooth mode
+
+This integration now includes an experimental `Bluetooth local` connection mode for Micronova stoves equipped with a local BLE module (for example the Micronova / Navel `T009_*` module seen by Home Assistant).
+
+### What it does
+
+- keeps the existing cloud setup and entity model
+- adds a Home Assistant Bluetooth transport for reading buffers and sending writes locally
+- works with Home Assistant Bluetooth adapters and Bluetooth proxies such as ESPHome `bluetooth_proxy`
+- stores the BLE bootstrap data in the config entry once discovered so normal operation can run locally
+
+### How it works
+
+The local transport talks to the Micronova BLE module with the same command family used by the vendor app:
+
+- `Identity`
+- `GetBufferId`
+- `GetBufferReading`
+- `RequestWriting`
+
+The integration still needs one successful cloud bootstrap to learn the device metadata required for local control:
+
+- BLE identity / MAC reference exposed by the Micronova API
+- BLE security code
+- register map for the stove model
+
+After that bootstrap data is cached in Home Assistant, reads and writes can run locally over Bluetooth through Home Assistant's Bluetooth stack.
+
+### How to enable it
+
+1. Set up the integration normally with your vendor cloud account.
+2. Make sure Home Assistant can reach the stove over Bluetooth, either directly or through a Bluetooth proxy close to the stove.
+3. Open the integration options.
+4. Change `Connection mode` to `Bluetooth local`.
+5. Leave the default BLE service / characteristic UUIDs unless you know your module uses different ones.
+
+### Current scope and limitations
+
+- this mode is experimental
+- the first bootstrap still depends on the vendor cloud API
+- compatibility is expected to vary depending on the Micronova firmware, BLE module, and stove register map
+- no guarantee is made for every supported vendor app or every Micronova-based stove
+
+### Tested hardware
+
+This mode has been validated on:
+
+- vendor app: `Jolly Mec Wi Fi`
+- stove / insert: `SYNTHESIS/1/80/M`
+- user-facing model reference: `Jolly Mec Modular Synthesis 80`
+- local BLE module advertising as `T009_*`
+
+If you test another stove or another vendor app and it works, please report the exact model and module details in your feedback.
+
 ## Credits
 
 Some parts of the code are based on [py-agua-iot](https://github.com/fredericvl/py-agua-iot)
 
 ## Related
 
-For local stove control, without need for the Micronova cloud platform, take a look at one of these projects (custom hardware required). 
+For local stove control with custom hardware on the stove bus, take a look at one of these projects.
 * https://esphome.io/components/micronova.html
 * https://github.com/eni23/micronova-controller
 * https://github.com/fabrizioromanelli/Pellet-Stove-Control

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ After that bootstrap data is cached in Home Assistant, reads and writes can run 
 2. Make sure Home Assistant can reach the stove over Bluetooth, either directly or through a Bluetooth proxy close to the stove.
 3. Open the integration options.
 4. Change `Connection mode` to `Bluetooth local`.
-5. Leave the default BLE service / characteristic UUIDs unless you know your module uses different ones.
+5. Submit the form and let Home Assistant auto-detect and validate the nearby Micronova BLE module.
+
+The options flow performs a real BLE validation before it accepts the local mode, so a successful save means the module was detected and the local transport was able to talk to it.
 
 ### Current scope and limitations
 

--- a/custom_components/aguaiot/aguaiot.py
+++ b/custom_components/aguaiot/aguaiot.py
@@ -707,7 +707,9 @@ class Device(object):
         try:
             await self.__request_writing(items)
         except AguaIOTError as err:
-            raise AguaIOTError(f"Error while trying to set: items={items} ({err})") from err
+            raise AguaIOTError(
+                f"Error while trying to set: items={items} ({err})"
+            ) from err
 
     async def set_register_value_description(
         self, key, value_description, value_fallback=None, language=None

--- a/custom_components/aguaiot/aguaiot.py
+++ b/custom_components/aguaiot/aguaiot.py
@@ -3,6 +3,7 @@ the IOT Agua platform of Micronova
 """
 
 import asyncio
+import copy
 import jwt
 import logging
 import time
@@ -265,6 +266,7 @@ class aguaiot(object):
                     dev["name_product"],
                     res2["device_info"][0]["id_registers_map"],
                     self,
+                    device_info=res2["device_info"][0],
                 )
             )
 
@@ -328,77 +330,45 @@ class aguaiot(object):
 
         return response.json()
 
-
-class Device(object):
-    """Agua IOT heating device representation"""
-
-    def __init__(
-        self,
-        id,
-        id_device,
-        id_product,
-        product_serial,
-        name,
-        is_online,
-        name_product,
-        id_registers_map,
-        aguaiot,
-    ):
-        self.id = id
-        self.id_device = id_device
-        self.id_product = id_product
-        self.product_serial = product_serial
-        self.name = name
-        self.is_online = is_online
-        self.name_product = name_product
-        self.id_registers_map = id_registers_map
-        self.__aguaiot = aguaiot
-        self.__register_map_dict = dict()
-        self.__information_dict = dict()
-
-    async def update_mapping(self):
-        await self.__update_device_registers_mapping()
-
-    async def update(self):
-        await self.__update_device_information()
-
-    async def __update_device_registers_mapping(self):
-        url = self.__aguaiot.api_url + API_PATH_DEVICE_REGISTERS_MAP
+    async def _fetch_device_registers_mapping(self, device):
+        """Fetch registers map for a device."""
+        url = self.api_url + API_PATH_DEVICE_REGISTERS_MAP
         registers = dict()
 
         payload = {
-            "id_device": self.id_device,
-            "id_product": self.id_product,
+            "id_device": device.id_device,
+            "id_product": device.id_product,
             "last_update": "2018-06-03T08:59:54.043",
         }
 
-        res = await self.__aguaiot.handle_webcall("POST", url, payload)
+        res = await self.handle_webcall("POST", url, payload)
         if res is False:
             raise AguaIOTError("Error while fetching registers map")
 
         for registers_map in res["device_registers_map"]["registers_map"]:
-            if registers_map["id"] == self.id_registers_map:
+            if registers_map["id"] == device.id_registers_map:
                 registers = {
                     reg["reg_key"].lower(): reg for reg in registers_map["registers"]
                 }
 
-        self.__register_map_dict = registers
+        return registers
 
-    async def __update_device_information(self):
-        url = self.__aguaiot.api_url + API_PATH_DEVICE_BUFFER_READING
+    async def _fetch_device_information(self, device):
+        """Fetch current register values for a device."""
+        url = self.api_url + API_PATH_DEVICE_BUFFER_READING
 
         payload = {
-            "id_device": self.id_device,
-            "id_product": self.id_product,
+            "id_device": device.id_device,
+            "id_product": device.id_product,
             "BufferId": 1,
         }
 
-        res_req = await self.__aguaiot.handle_webcall("POST", url, payload)
+        res_req = await self.handle_webcall("POST", url, payload)
         if res_req is False:
             raise AguaIOTError("Error while making device buffer read request.")
 
         async def buffer_read_loop(id_request):
-            url = self.__aguaiot.api_url + API_PATH_DEVICE_JOB_STATUS + id_request
+            url = self.api_url + API_PATH_DEVICE_JOB_STATUS + id_request
             sleep_secs = 1
             attempts = 1
 
@@ -407,7 +377,7 @@ class Device(object):
                     await asyncio.sleep(sleep_secs)
 
                     _LOGGER.debug("BUFFER READ (%s) ATTEMPT %s", id_request, attempts)
-                    res_get = await self.__aguaiot.handle_webcall("GET", url, {})
+                    res_get = await self.handle_webcall("GET", url, {})
                     _LOGGER.debug(
                         "BUFFER READ (%s) STATUS: %s",
                         id_request,
@@ -424,11 +394,11 @@ class Device(object):
         try:
             res = await asyncio.wait_for(
                 buffer_read_loop(res_req["idRequest"]),
-                self.__aguaiot.buffer_read_timeout,
+                self.buffer_read_timeout,
             )
         except asyncio.TimeoutError:
             raise AguaIOTUpdateError(
-                f"Timeout on waiting device buffer read to complete within {self.__aguaiot.buffer_read_timeout} seconds."
+                f"Timeout on waiting device buffer read to complete within {self.buffer_read_timeout} seconds."
             )
 
         if not res:
@@ -446,11 +416,104 @@ class Device(object):
             except KeyError:
                 raise AguaIOTUpdateError("Error in data received from device.")
 
-            self.__information_dict = information_dict
-        else:
-            raise AguaIOTUpdateError(
-                f"Received unexpected 'jobAnswerStatus' while reading buffers: {res.get('jobAnswerStatus')}"
-            )
+            return information_dict
+
+        raise AguaIOTUpdateError(
+            f"Received unexpected 'jobAnswerStatus' while reading buffers: {res.get('jobAnswerStatus')}"
+        )
+
+    async def _request_writing(self, device, items):
+        """Write raw register values for a device."""
+        url = self.api_url + API_PATH_DEVICE_WRITING
+
+        set_items = []
+        set_masks = []
+        set_bits = []
+        set_endians = []
+        set_values = []
+
+        for key in items:
+            set_items.append(int(device.get_register(key)["offset"]))
+            set_masks.append(int(device.get_register(key)["mask"]))
+            set_values.append(items[key])
+            set_bits.append(8)
+            set_endians.append("L")
+
+        payload = {
+            "id_device": device.id_device,
+            "id_product": device.id_product,
+            "Protocol": "RWMSmaster",
+            "BitData": set_bits,
+            "Endianess": set_endians,
+            "Items": set_items,
+            "Masks": set_masks,
+            "Values": set_values,
+        }
+
+        res = await self.handle_webcall("POST", url, payload)
+        if res is False:
+            raise AguaIOTError("Error while request device writing")
+
+        id_request = res["idRequest"]
+
+        url = self.api_url + API_PATH_DEVICE_JOB_STATUS + id_request
+
+        payload = {}
+
+        retry_count = 0
+        res = await self.handle_webcall("GET", url, payload)
+        while (
+            res is False or res["jobAnswerStatus"] != "completed"
+        ) and retry_count < 10:
+            await asyncio.sleep(1)
+            res = await self.handle_webcall("GET", url, payload)
+            retry_count = retry_count + 1
+
+        if (
+            res is False
+            or res["jobAnswerStatus"] != "completed"
+            or "Cmd" not in res["jobAnswerData"]
+        ):
+            raise AguaIOTError("Error while request device writing")
+
+
+class Device(object):
+    """Agua IOT heating device representation"""
+
+    def __init__(
+        self,
+        id,
+        id_device,
+        id_product,
+        product_serial,
+        name,
+        is_online,
+        name_product,
+        id_registers_map,
+        aguaiot,
+        device_info=None,
+        register_map=None,
+    ):
+        self.id = id
+        self.id_device = id_device
+        self.id_product = id_product
+        self.product_serial = product_serial
+        self.name = name
+        self.is_online = is_online
+        self.name_product = name_product
+        self.id_registers_map = id_registers_map
+        self.__aguaiot = aguaiot
+        self.__device_info = device_info or dict()
+        self.__register_map_dict = register_map or dict()
+        self.__information_dict = dict()
+
+    async def update_mapping(self):
+        self.__register_map_dict = await self.__aguaiot._fetch_device_registers_mapping(
+            self
+        )
+
+    async def update(self):
+        self.__information_dict = await self.__aguaiot._fetch_device_information(self)
 
     def __prepare_value_for_writing(self, item, value, limit_value_raw=False):
         set_min = self.__register_map_dict[item]["set_min"]
@@ -479,61 +542,40 @@ class Device(object):
         return value
 
     async def __request_writing(self, items):
-        url = self.__aguaiot.api_url + API_PATH_DEVICE_WRITING
-
-        set_items = []
-        set_masks = []
-        set_bits = []
-        set_endians = []
-        set_values = []
-
-        for key in items:
-            set_items.append(int(self.__register_map_dict[key]["offset"]))
-            set_masks.append(int(self.__register_map_dict[key]["mask"]))
-            set_values.append(items[key])
-            set_bits.append(8)
-            set_endians.append("L")
-
-        payload = {
-            "id_device": self.id_device,
-            "id_product": self.id_product,
-            "Protocol": "RWMSmaster",
-            "BitData": set_bits,
-            "Endianess": set_endians,
-            "Items": set_items,
-            "Masks": set_masks,
-            "Values": set_values,
-        }
-
-        res = await self.__aguaiot.handle_webcall("POST", url, payload)
-        if res is False:
-            raise AguaIOTError("Error while request device writing")
-
-        id_request = res["idRequest"]
-
-        url = self.__aguaiot.api_url + API_PATH_DEVICE_JOB_STATUS + id_request
-
-        payload = {}
-
-        retry_count = 0
-        res = await self.__aguaiot.handle_webcall("GET", url, payload)
-        while (
-            res is False or res["jobAnswerStatus"] != "completed"
-        ) and retry_count < 10:
-            await asyncio.sleep(1)
-            res = await self.__aguaiot.handle_webcall("GET", url, payload)
-            retry_count = retry_count + 1
-
-        if (
-            res is False
-            or res["jobAnswerStatus"] != "completed"
-            or "Cmd" not in res["jobAnswerData"]
-        ):
-            raise AguaIOTError("Error while request device writing")
+        await self.__aguaiot._request_writing(self, items)
 
     @property
     def registers(self):
         return list(self.__register_map_dict.keys())
+
+    @property
+    def device_info_data(self):
+        return self.__device_info
+
+    @property
+    def ble_mac(self):
+        return self.__device_info.get("mac")
+
+    @property
+    def ble_security_code(self):
+        return self.__device_info.get("security_code")
+
+    def export_register_map(self):
+        return copy.deepcopy(self.__register_map_dict)
+
+    def export_cache(self):
+        return {
+            "id": self.id,
+            "id_device": self.id_device,
+            "id_product": self.id_product,
+            "product_serial": self.product_serial,
+            "name": self.name,
+            "is_online": self.is_online,
+            "name_product": self.name_product,
+            "id_registers_map": self.id_registers_map,
+            "device_info": copy.deepcopy(self.__device_info),
+            "register_map": self.export_register_map(),
+        }
 
     def get_register(self, key):
         register = self.__register_map_dict.get(key, {})
@@ -651,8 +693,10 @@ class Device(object):
 
         try:
             await self.__request_writing(items)
-        except AguaIOTError:
-            raise AguaIOTError(f"Error while trying to set: key={key} value={value}")
+        except AguaIOTError as err:
+            raise AguaIOTError(
+                f"Error while trying to set: key={key} value={value} ({err})"
+            ) from err
 
     async def set_register_values(self, items, limit_value_raw=False):
         for key in items:
@@ -662,8 +706,8 @@ class Device(object):
 
         try:
             await self.__request_writing(items)
-        except AguaIOTError:
-            raise AguaIOTError(f"Error while trying to set: items={items}")
+        except AguaIOTError as err:
+            raise AguaIOTError(f"Error while trying to set: items={items} ({err})") from err
 
     async def set_register_value_description(
         self, key, value_description, value_fallback=None, language=None

--- a/custom_components/aguaiot/climate.py
+++ b/custom_components/aguaiot/climate.py
@@ -158,6 +158,28 @@ class AguaIOTAirDevice(AguaIOTClimateDevice):
                 self._temperature_set_key = f"temp_{variant}_set"
                 break
 
+    def _status_description_upper(self):
+        """Return the current status description in a normalized uppercase form."""
+        status_value = self._device.get_register_value("status_get")
+        if status_value is None:
+            return None
+
+        description = self._device.get_register_value_description(
+            key="status_get", language="ENG"
+        )
+        if description is None:
+            return None
+
+        return str(description).strip().upper()
+
+    def _is_alarm_like_status(self):
+        """Return True for Micronova alarm/manual-alarm style states."""
+        description = self._status_description_upper()
+        if description is None:
+            return False
+
+        return "ALARM" in description or "ALLARM" in description
+
     @property
     def unique_id(self):
         """Return a unique ID."""
@@ -179,25 +201,14 @@ class AguaIOTAirDevice(AguaIOTClimateDevice):
     @property
     def hvac_action(self):
         """Return the current running hvac operation."""
-        if self._device.get_register_value("status_get") is not None:
-            if (
-                str(
-                    self._device.get_register_value_description(
-                        key="status_get", language="ENG"
-                    )
-                ).upper()
-                in STATUS_IDLE
-            ):
+        status_value = self._device.get_register_value("status_get")
+        if status_value is not None:
+            description = self._status_description_upper()
+            if self._is_alarm_like_status():
+                return HVACAction.OFF
+            if description in STATUS_IDLE:
                 return HVACAction.IDLE
-            elif (
-                self._device.get_register_value("status_get") == 0
-                or str(
-                    self._device.get_register_value_description(
-                        key="status_get", language="ENG"
-                    )
-                ).upper()
-                in STATUS_OFF
-            ):
+            elif status_value == 0 or description in STATUS_OFF:
                 return HVACAction.OFF
             return HVACAction.HEATING
 
@@ -209,16 +220,10 @@ class AguaIOTAirDevice(AguaIOTClimateDevice):
     @property
     def hvac_mode(self):
         """Return hvac operation ie. heat, cool mode."""
-        if self._device.get_register_value("status_get") is not None:
-            if (
-                self._device.get_register_value("status_get") == 0
-                or str(
-                    self._device.get_register_value_description(
-                        key="status_get", language="ENG"
-                    )
-                ).upper()
-                in STATUS_OFF
-            ):
+        status_value = self._device.get_register_value("status_get")
+        if status_value is not None:
+            description = self._status_description_upper()
+            if self._is_alarm_like_status() or status_value == 0 or description in STATUS_OFF:
                 return HVACMode.OFF
             return HVACMode.HEAT
 

--- a/custom_components/aguaiot/climate.py
+++ b/custom_components/aguaiot/climate.py
@@ -223,7 +223,11 @@ class AguaIOTAirDevice(AguaIOTClimateDevice):
         status_value = self._device.get_register_value("status_get")
         if status_value is not None:
             description = self._status_description_upper()
-            if self._is_alarm_like_status() or status_value == 0 or description in STATUS_OFF:
+            if (
+                self._is_alarm_like_status()
+                or status_value == 0
+                or description in STATUS_OFF
+            ):
                 return HVACMode.OFF
             return HVACMode.HEAT
 

--- a/custom_components/aguaiot/config_flow.py
+++ b/custom_components/aguaiot/config_flow.py
@@ -166,7 +166,9 @@ class AguaIOTOptionsFlowHandler(OptionsFlowWithReload):
             "brand": entry.data.get(CONF_BRAND),
             "async_client": get_async_client(self.hass),
             "air_temp_fix": self.config_entry.options.get(CONF_AIR_TEMP_FIX, False),
-            "reading_error_fix": self.config_entry.options.get(CONF_READING_ERROR_FIX, False),
+            "reading_error_fix": self.config_entry.options.get(
+                CONF_READING_ERROR_FIX, False
+            ),
             "language": self.config_entry.options.get(CONF_LANGUAGE, "ENG"),
             "http_timeout": self.config_entry.options.get(CONF_HTTP_TIMEOUT, 30),
             "buffer_read_timeout": self.config_entry.options.get(
@@ -272,7 +274,9 @@ class AguaIOTOptionsFlowHandler(OptionsFlowWithReload):
         if user_input is not None:
             connection_mode = user_input.get(
                 CONF_CONNECTION_MODE,
-                self.config_entry.options.get(CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD),
+                self.config_entry.options.get(
+                    CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD
+                ),
             )
             try:
                 agua = self._build_client(connection_mode)

--- a/custom_components/aguaiot/config_flow.py
+++ b/custom_components/aguaiot/config_flow.py
@@ -9,7 +9,7 @@ from .aguaiot import (
     AguaIOTUnauthorized,
     aguaiot,
 )
-from .local_ble import DEFAULT_CHAR_UUID, DEFAULT_SERVICE_UUID, LocalBleAguaIOT
+from .local_ble import LocalBleAguaIOT
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -25,8 +25,6 @@ from homeassistant.helpers.httpx_client import get_async_client
 from .const import (
     CONF_API_URL,
     CONF_BLE_BOOTSTRAP_DEVICES,
-    CONF_BLE_CHAR_UUID,
-    CONF_BLE_SERVICE_UUID,
     CONF_CONNECTION_MODE,
     CONF_CUSTOMER_CODE,
     CONF_LOGIN_API_URL,
@@ -154,126 +152,147 @@ class AguaIOTOptionsFlowHandler(OptionsFlowWithReload):
         """Manage the options."""
         return await self.async_step_user()
 
-    async def async_step_user(self, user_input=None):
-        """Handle a flow initialized by the user."""
-
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        """Set up AguaIOT entry."""
+    def _build_client(self, connection_mode):
+        """Create the configured cloud or local BLE transport."""
         entry = self.config_entry
-
-        api_url = entry.data.get(CONF_API_URL)
-        customer_code = entry.data.get(CONF_CUSTOMER_CODE)
-        email = entry.data.get(CONF_EMAIL)
-        password = entry.data.get(CONF_PASSWORD)
-        gen_uuid = entry.data.get(CONF_UUID)
-        login_api_url = entry.data.get(CONF_LOGIN_API_URL)
-        brand_id = entry.data.get(CONF_BRAND_ID)
-        brand = entry.data.get(CONF_BRAND)
-        connection_mode = self.config_entry.options.get(
-            CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD
-        )
-        cached_devices = entry.data.get(CONF_BLE_BOOTSTRAP_DEVICES)
-        ble_service_uuid = self.config_entry.options.get(
-            CONF_BLE_SERVICE_UUID, DEFAULT_SERVICE_UUID
-        )
-        ble_char_uuid = self.config_entry.options.get(
-            CONF_BLE_CHAR_UUID, DEFAULT_CHAR_UUID
-        )
-
-        agua_kwargs = {
-            "api_url": api_url,
-            "customer_code": customer_code,
-            "email": email,
-            "password": password,
-            "unique_id": gen_uuid,
-            "login_api_url": login_api_url,
-            "brand_id": brand_id,
-            "brand": brand,
+        return_kwargs = {
+            "api_url": entry.data.get(CONF_API_URL),
+            "customer_code": entry.data.get(CONF_CUSTOMER_CODE),
+            "email": entry.data.get(CONF_EMAIL),
+            "password": entry.data.get(CONF_PASSWORD),
+            "unique_id": entry.data.get(CONF_UUID),
+            "login_api_url": entry.data.get(CONF_LOGIN_API_URL),
+            "brand_id": entry.data.get(CONF_BRAND_ID),
+            "brand": entry.data.get(CONF_BRAND),
             "async_client": get_async_client(self.hass),
+            "air_temp_fix": self.config_entry.options.get(CONF_AIR_TEMP_FIX, False),
+            "reading_error_fix": self.config_entry.options.get(CONF_READING_ERROR_FIX, False),
+            "language": self.config_entry.options.get(CONF_LANGUAGE, "ENG"),
+            "http_timeout": self.config_entry.options.get(CONF_HTTP_TIMEOUT, 30),
+            "buffer_read_timeout": self.config_entry.options.get(
+                CONF_BUFFER_READ_TIMEOUT, 30
+            ),
         }
 
         if connection_mode == CONNECTION_MODE_BLUETOOTH:
-            agua = LocalBleAguaIOT(
+            return LocalBleAguaIOT(
                 hass=self.hass,
-                cached_devices=cached_devices,
-                service_uuid=ble_service_uuid,
-                char_uuid=ble_char_uuid,
-                **agua_kwargs,
+                cached_devices=entry.data.get(CONF_BLE_BOOTSTRAP_DEVICES),
+                **return_kwargs,
             )
-        else:
-            agua = aguaiot(**agua_kwargs)
 
-        try:
-            await agua.connect()
-        except AguaIOTUnauthorized as e:
-            _LOGGER.error("Agua IOT Unauthorized: %s", e)
-            return False
-        except AguaIOTConnectionError as e:
-            _LOGGER.error("Agua IOT Connection error: %s", e)
-            return False
-        except AguaIOTError as e:
-            _LOGGER.error("Agua IOT error: %s", e)
-            return False
+        return aguaiot(**return_kwargs)
 
+    def _languages(self):
+        """Return the available register description languages."""
         languages = ["ENG"]
-        if agua.devices:
-            languages = sorted(
-                list(
-                    agua.devices[0].get_register_value_options_languages(
-                        "status_managed_get"
+        coordinator = self.config_entry.runtime_data
+        agua = getattr(coordinator, "agua", None)
+        if agua and getattr(agua, "devices", None):
+            try:
+                languages = sorted(
+                    list(
+                        agua.devices[0].get_register_value_options_languages(
+                            "status_managed_get"
+                        )
                     )
                 )
-            )
+            except (KeyError, IndexError, AttributeError):
+                pass
 
+        return languages
+
+    def _build_schema(self, user_input=None):
+        """Build the options form schema."""
+        user_input = user_input or {}
         schema = {
             vol.Optional(
                 CONF_AIR_TEMP_FIX,
-                default=self.config_entry.options.get(CONF_AIR_TEMP_FIX, False),
+                default=user_input.get(
+                    CONF_AIR_TEMP_FIX,
+                    self.config_entry.options.get(CONF_AIR_TEMP_FIX, False),
+                ),
             ): bool,
             vol.Optional(
                 CONF_READING_ERROR_FIX,
-                default=self.config_entry.options.get(CONF_READING_ERROR_FIX, False),
+                default=user_input.get(
+                    CONF_READING_ERROR_FIX,
+                    self.config_entry.options.get(CONF_READING_ERROR_FIX, False),
+                ),
             ): bool,
             vol.Optional(
                 CONF_UPDATE_INTERVAL,
-                default=self.config_entry.options.get(CONF_UPDATE_INTERVAL, 60),
+                default=user_input.get(
+                    CONF_UPDATE_INTERVAL,
+                    self.config_entry.options.get(CONF_UPDATE_INTERVAL, 60),
+                ),
             ): vol.All(vol.Coerce(int), vol.Range(min=10)),
             vol.Optional(
                 CONF_HTTP_TIMEOUT,
-                default=self.config_entry.options.get(CONF_HTTP_TIMEOUT, 30),
+                default=user_input.get(
+                    CONF_HTTP_TIMEOUT,
+                    self.config_entry.options.get(CONF_HTTP_TIMEOUT, 30),
+                ),
             ): vol.All(vol.Coerce(int), vol.Range(max=60)),
             vol.Optional(
                 CONF_BUFFER_READ_TIMEOUT,
-                default=self.config_entry.options.get(CONF_BUFFER_READ_TIMEOUT, 30),
+                default=user_input.get(
+                    CONF_BUFFER_READ_TIMEOUT,
+                    self.config_entry.options.get(CONF_BUFFER_READ_TIMEOUT, 30),
+                ),
             ): vol.All(vol.Coerce(int), vol.Range(max=60)),
             vol.Optional(
                 CONF_CONNECTION_MODE,
-                default=self.config_entry.options.get(
-                CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD
+                default=user_input.get(
+                    CONF_CONNECTION_MODE,
+                    self.config_entry.options.get(
+                        CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD
+                    ),
                 ),
             ): vol.In(
                 {
                     CONNECTION_MODE_CLOUD: "Cloud (Micronova API)",
-                    CONNECTION_MODE_BLUETOOTH: "Bluetooth local (experimental)",
+                    CONNECTION_MODE_BLUETOOTH: "Bluetooth local (auto-detect)",
                 }
             ),
             vol.Optional(
-                CONF_BLE_SERVICE_UUID,
-                default=self.config_entry.options.get(
-                    CONF_BLE_SERVICE_UUID, DEFAULT_SERVICE_UUID
-                ),
-            ): str,
-            vol.Optional(
-                CONF_BLE_CHAR_UUID,
-                default=self.config_entry.options.get(
-                    CONF_BLE_CHAR_UUID, DEFAULT_CHAR_UUID
-                ),
-            ): str,
-            vol.Optional(
                 CONF_LANGUAGE,
-                default=self.config_entry.options.get(CONF_LANGUAGE, "ENG"),
-            ): vol.In(languages),
+                default=user_input.get(
+                    CONF_LANGUAGE,
+                    self.config_entry.options.get(CONF_LANGUAGE, "ENG"),
+                ),
+            ): vol.In(self._languages()),
         }
-        return self.async_show_form(step_id="user", data_schema=vol.Schema(schema))
+        return vol.Schema(schema)
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        errors = {}
+
+        if user_input is not None:
+            connection_mode = user_input.get(
+                CONF_CONNECTION_MODE,
+                self.config_entry.options.get(CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD),
+            )
+            try:
+                agua = self._build_client(connection_mode)
+                await agua.connect()
+                if connection_mode == CONNECTION_MODE_BLUETOOTH:
+                    await agua.validate_local_connection()
+            except AguaIOTUnauthorized as e:
+                _LOGGER.error("Agua IOT Unauthorized: %s", e)
+                errors["base"] = "unauthorized"
+            except AguaIOTConnectionError as e:
+                _LOGGER.error("Agua IOT Connection error: %s", e)
+                errors["base"] = "connection_error"
+            except AguaIOTError as e:
+                _LOGGER.error("Agua IOT error: %s", e)
+                errors["base"] = "unknown_error"
+            else:
+                return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self._build_schema(user_input),
+            errors=errors,
+        )

--- a/custom_components/aguaiot/config_flow.py
+++ b/custom_components/aguaiot/config_flow.py
@@ -9,6 +9,7 @@ from .aguaiot import (
     AguaIOTUnauthorized,
     aguaiot,
 )
+from .local_ble import DEFAULT_CHAR_UUID, DEFAULT_SERVICE_UUID, LocalBleAguaIOT
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -23,6 +24,10 @@ from homeassistant.helpers.httpx_client import get_async_client
 
 from .const import (
     CONF_API_URL,
+    CONF_BLE_BOOTSTRAP_DEVICES,
+    CONF_BLE_CHAR_UUID,
+    CONF_BLE_SERVICE_UUID,
+    CONF_CONNECTION_MODE,
     CONF_CUSTOMER_CODE,
     CONF_LOGIN_API_URL,
     CONF_UUID,
@@ -35,6 +40,8 @@ from .const import (
     CONF_UPDATE_INTERVAL,
     CONF_HTTP_TIMEOUT,
     CONF_BUFFER_READ_TIMEOUT,
+    CONNECTION_MODE_BLUETOOTH,
+    CONNECTION_MODE_CLOUD,
     DOMAIN,
     ENDPOINTS,
 )
@@ -164,18 +171,39 @@ class AguaIOTOptionsFlowHandler(OptionsFlowWithReload):
         login_api_url = entry.data.get(CONF_LOGIN_API_URL)
         brand_id = entry.data.get(CONF_BRAND_ID)
         brand = entry.data.get(CONF_BRAND)
-
-        agua = aguaiot(
-            api_url=api_url,
-            customer_code=customer_code,
-            email=email,
-            password=password,
-            unique_id=gen_uuid,
-            login_api_url=login_api_url,
-            brand_id=brand_id,
-            brand=brand,
-            async_client=get_async_client(self.hass),
+        connection_mode = self.config_entry.options.get(
+            CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD
         )
+        cached_devices = entry.data.get(CONF_BLE_BOOTSTRAP_DEVICES)
+        ble_service_uuid = self.config_entry.options.get(
+            CONF_BLE_SERVICE_UUID, DEFAULT_SERVICE_UUID
+        )
+        ble_char_uuid = self.config_entry.options.get(
+            CONF_BLE_CHAR_UUID, DEFAULT_CHAR_UUID
+        )
+
+        agua_kwargs = {
+            "api_url": api_url,
+            "customer_code": customer_code,
+            "email": email,
+            "password": password,
+            "unique_id": gen_uuid,
+            "login_api_url": login_api_url,
+            "brand_id": brand_id,
+            "brand": brand,
+            "async_client": get_async_client(self.hass),
+        }
+
+        if connection_mode == CONNECTION_MODE_BLUETOOTH:
+            agua = LocalBleAguaIOT(
+                hass=self.hass,
+                cached_devices=cached_devices,
+                service_uuid=ble_service_uuid,
+                char_uuid=ble_char_uuid,
+                **agua_kwargs,
+            )
+        else:
+            agua = aguaiot(**agua_kwargs)
 
         try:
             await agua.connect()
@@ -220,6 +248,29 @@ class AguaIOTOptionsFlowHandler(OptionsFlowWithReload):
                 CONF_BUFFER_READ_TIMEOUT,
                 default=self.config_entry.options.get(CONF_BUFFER_READ_TIMEOUT, 30),
             ): vol.All(vol.Coerce(int), vol.Range(max=60)),
+            vol.Optional(
+                CONF_CONNECTION_MODE,
+                default=self.config_entry.options.get(
+                CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD
+                ),
+            ): vol.In(
+                {
+                    CONNECTION_MODE_CLOUD: "Cloud (Micronova API)",
+                    CONNECTION_MODE_BLUETOOTH: "Bluetooth local (experimental)",
+                }
+            ),
+            vol.Optional(
+                CONF_BLE_SERVICE_UUID,
+                default=self.config_entry.options.get(
+                    CONF_BLE_SERVICE_UUID, DEFAULT_SERVICE_UUID
+                ),
+            ): str,
+            vol.Optional(
+                CONF_BLE_CHAR_UUID,
+                default=self.config_entry.options.get(
+                    CONF_BLE_CHAR_UUID, DEFAULT_CHAR_UUID
+                ),
+            ): str,
             vol.Optional(
                 CONF_LANGUAGE,
                 default=self.config_entry.options.get(CONF_LANGUAGE, "ENG"),

--- a/custom_components/aguaiot/const.py
+++ b/custom_components/aguaiot/const.py
@@ -77,6 +77,13 @@ CONF_READING_ERROR_FIX = "reading_error_fix"
 CONF_UPDATE_INTERVAL = "update_interval"
 CONF_HTTP_TIMEOUT = "http_timeout"
 CONF_BUFFER_READ_TIMEOUT = "buffer_read_timeout"
+CONF_CONNECTION_MODE = "connection_mode"
+CONF_BLE_BOOTSTRAP_DEVICES = "ble_bootstrap_devices"
+CONF_BLE_SERVICE_UUID = "ble_service_uuid"
+CONF_BLE_CHAR_UUID = "ble_char_uuid"
+
+CONNECTION_MODE_CLOUD = "cloud"
+CONNECTION_MODE_BLUETOOTH = "bluetooth_local"
 
 AIR_VARIANTS = ["air", "air2", "air3", "air_palm"]
 WATER_VARIANTS = ["water", "h2o", "h2o_mandata"]

--- a/custom_components/aguaiot/coordinator.py
+++ b/custom_components/aguaiot/coordinator.py
@@ -18,9 +18,14 @@ from .aguaiot import (
     AguaIOTUpdateError,
     aguaiot,
 )
+from .local_ble import DEFAULT_CHAR_UUID, DEFAULT_SERVICE_UUID, LocalBleAguaIOT
 
 from .const import (
     CONF_API_URL,
+    CONF_BLE_BOOTSTRAP_DEVICES,
+    CONF_BLE_CHAR_UUID,
+    CONF_BLE_SERVICE_UUID,
+    CONF_CONNECTION_MODE,
     CONF_CUSTOMER_CODE,
     CONF_LOGIN_API_URL,
     CONF_UUID,
@@ -32,6 +37,8 @@ from .const import (
     CONF_UPDATE_INTERVAL,
     CONF_HTTP_TIMEOUT,
     CONF_BUFFER_READ_TIMEOUT,
+    CONNECTION_MODE_BLUETOOTH,
+    CONNECTION_MODE_CLOUD,
     DOMAIN,
 )
 
@@ -69,30 +76,49 @@ class AguaIOTDataUpdateCoordinator(DataUpdateCoordinator):
         air_temp_fix = config_entry.options.get(CONF_AIR_TEMP_FIX, False)
         reading_error_fix = config_entry.options.get(CONF_READING_ERROR_FIX, False)
         language = config_entry.options.get(CONF_LANGUAGE)
-        http_timeout = config_entry.options.get(CONF_HTTP_TIMEOUT)
-        buffer_read_timeout = config_entry.options.get(CONF_BUFFER_READ_TIMEOUT)
-
-        self.agua = aguaiot(
-            api_url=api_url,
-            customer_code=customer_code,
-            email=email,
-            password=password,
-            unique_id=gen_uuid,
-            login_api_url=login_api_url,
-            brand_id=brand_id,
-            brand=brand,
-            async_client=get_async_client(hass),
-            air_temp_fix=air_temp_fix,
-            reading_error_fix=reading_error_fix,
-            language=language,
-            http_timeout=http_timeout,
-            buffer_read_timeout=buffer_read_timeout,
+        http_timeout = config_entry.options.get(CONF_HTTP_TIMEOUT, 30)
+        buffer_read_timeout = config_entry.options.get(CONF_BUFFER_READ_TIMEOUT, 30)
+        connection_mode = config_entry.options.get(
+            CONF_CONNECTION_MODE, CONNECTION_MODE_CLOUD
         )
+
+        client_kwargs = {
+            "api_url": api_url,
+            "customer_code": customer_code,
+            "email": email,
+            "password": password,
+            "unique_id": gen_uuid,
+            "login_api_url": login_api_url,
+            "brand_id": brand_id,
+            "brand": brand,
+            "async_client": get_async_client(hass),
+            "air_temp_fix": air_temp_fix,
+            "reading_error_fix": reading_error_fix,
+            "language": language,
+            "http_timeout": http_timeout,
+            "buffer_read_timeout": buffer_read_timeout,
+        }
+
+        if connection_mode == CONNECTION_MODE_BLUETOOTH:
+            self.agua = LocalBleAguaIOT(
+                hass=hass,
+                cached_devices=config_entry.data.get(CONF_BLE_BOOTSTRAP_DEVICES),
+                service_uuid=config_entry.options.get(
+                    CONF_BLE_SERVICE_UUID, DEFAULT_SERVICE_UUID
+                ),
+                char_uuid=config_entry.options.get(
+                    CONF_BLE_CHAR_UUID, DEFAULT_CHAR_UUID
+                ),
+                **client_kwargs,
+            )
+        else:
+            self.agua = aguaiot(**client_kwargs)
 
     async def _async_setup(self) -> None:
         """Connect to the AguaIOT platform"""
         try:
             await self.agua.connect()
+            await self._async_persist_ble_bootstrap_if_needed()
         except AguaIOTUpdateError as e:
             _LOGGER.error("Agua IOT Update error: %s", e)
         except AguaIOTUnauthorized as e:
@@ -106,6 +132,7 @@ class AguaIOTDataUpdateCoordinator(DataUpdateCoordinator):
         """Get the latest data."""
         try:
             await self.agua.update()
+            await self._async_persist_ble_bootstrap_if_needed()
         except AguaIOTUpdateError as e:
             _LOGGER.error("Agua IOT Update error: %s", e)
         except AguaIOTUnauthorized as e:
@@ -114,3 +141,18 @@ class AguaIOTDataUpdateCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Agua IOT Connection error: {e}") from e
         except AguaIOTError as e:
             raise UpdateFailed(f"Agua IOT error: {e}") from e
+
+    async def _async_persist_ble_bootstrap_if_needed(self) -> None:
+        """Persist BLE bootstrap data when it is freshly learned from the cloud."""
+        if not isinstance(self.agua, LocalBleAguaIOT) or not self.agua.cache_dirty:
+            return
+
+        updated_data = {
+            **self.config_entry.data,
+            CONF_BLE_BOOTSTRAP_DEVICES: self.agua.export_bootstrap_cache(),
+        }
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data=updated_data,
+        )
+        self.agua.mark_cache_persisted()

--- a/custom_components/aguaiot/local_ble.py
+++ b/custom_components/aguaiot/local_ble.py
@@ -15,7 +15,13 @@ from bleak_retry_connector import BleakClientWithServiceCache, establish_connect
 from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant
 
-from .aguaiot import AguaIOTConnectionError, AguaIOTError, AguaIOTUpdateError, Device, aguaiot
+from .aguaiot import (
+    AguaIOTConnectionError,
+    AguaIOTError,
+    AguaIOTUpdateError,
+    Device,
+    aguaiot,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -145,7 +151,9 @@ class LocalBleAguaIOT:
     async def validate_local_connection(self) -> dict[str, Any]:
         """Detect and validate the local BLE module for the first configured stove."""
         if not self.devices:
-            raise AguaIOTError("No Micronova devices are available for local Bluetooth.")
+            raise AguaIOTError(
+                "No Micronova devices are available for local Bluetooth."
+            )
 
         device = self.devices[0]
         async with self._device_session(device) as session:
@@ -161,7 +169,8 @@ class LocalBleAguaIOT:
                 "device_name": device.name,
                 "module_address": session.connected_address
                 or self._device_ble_address(device),
-                "module_name": session.connected_name or self._expected_local_name(device),
+                "module_name": session.connected_name
+                or self._expected_local_name(device),
                 "buffer_ids": buffer_ids,
             }
             _LOGGER.info(
@@ -301,9 +310,7 @@ class LocalBleAguaIOT:
                 # Prime the local session the same way the vendor app does:
                 # it reads buffers before sending writes.
                 await session.get_buffer_reading(buffer_ids[0])
-            response = await session.exchange(
-                self._make_enveloped_command(payload)
-            )
+            response = await session.exchange(self._make_enveloped_command(payload))
             payload = response.get("pl", {})
             if payload.get("NackErrCode") is not None:
                 raise AguaIOTError(
@@ -447,9 +454,8 @@ class LocalBleAguaIOT:
                     )
                     return service_info.device
 
-                if (
-                    fallback_prefix_device is None
-                    and service_name.startswith(DEFAULT_NAME_PREFIX)
+                if fallback_prefix_device is None and service_name.startswith(
+                    DEFAULT_NAME_PREFIX
                 ):
                     fallback_prefix_device = service_info.device
 
@@ -539,7 +545,9 @@ class _BleMicronovaSession:
         if isinstance(self._resolved_target, str):
             return self._resolved_target.upper()
 
-        if self._resolved_target is not None and getattr(self._resolved_target, "address", None):
+        if self._resolved_target is not None and getattr(
+            self._resolved_target, "address", None
+        ):
             return str(self._resolved_target.address).upper()
 
         return None
@@ -596,7 +604,9 @@ class _BleMicronovaSession:
 
     async def identity(self) -> dict[str, Any]:
         """Authenticate the BLE session."""
-        response = await self.exchange(self._transport._make_identity_command(self._device))
+        response = await self.exchange(
+            self._transport._make_identity_command(self._device)
+        )
         payload = response.get("pl", {})
         if payload.get("NackErrCode") is not None:
             raise AguaIOTError(
@@ -657,13 +667,17 @@ class _BleMicronovaSession:
         assert self._client is not None
         assert self._characteristic_uuid is not None
 
-        body = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-        header = b"JSON" + struct.pack("<H", len(body)) + b"\xF9\x01"
+        body = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf-8"
+        )
+        header = b"JSON" + struct.pack("<H", len(body)) + b"\xf9\x01"
 
         self._response_ready.clear()
         self._notif_len = None
 
-        await self._client.write_gatt_char(self._characteristic_uuid, header, response=True)
+        await self._client.write_gatt_char(
+            self._characteristic_uuid, header, response=True
+        )
 
         mtu = getattr(self._client, "mtu_size", 23) or 23
         chunk_size = max(20, mtu - 3)

--- a/custom_components/aguaiot/local_ble.py
+++ b/custom_components/aguaiot/local_ble.py
@@ -1,0 +1,665 @@
+"""Local Bluetooth transport for Micronova T009/Navel modules."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import struct
+import uuid
+from typing import Any
+
+from bleak import BleakClient, BleakError
+from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+from homeassistant.components import bluetooth
+from homeassistant.core import HomeAssistant
+
+from .aguaiot import AguaIOTConnectionError, AguaIOTError, AguaIOTUpdateError, Device, aguaiot
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
+DEFAULT_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
+DEFAULT_NAME_PREFIX = "T009_"
+
+
+def _normalize_ble_address(value: str | None) -> str | None:
+    """Return a colon-separated BLE address."""
+    if not value:
+        return None
+
+    compact = re.sub(r"[^0-9A-Fa-f]", "", value)
+    if len(compact) == 12:
+        return ":".join(compact[i : i + 2] for i in range(0, 12, 2)).upper()
+
+    return value.upper()
+
+
+def _normalize_identity_id(value: str | None) -> str | None:
+    """Return the Micronova identity id format used in BLE JSON commands."""
+    if not value:
+        return None
+
+    compact = re.sub(r"[^0-9A-Fa-f]", "", value)
+    if compact:
+        return compact.upper()
+
+    return value
+
+
+def _increment_ble_address(value: str, delta: int) -> str:
+    """Return a BLE address with the last byte incremented by delta."""
+    compact = re.sub(r"[^0-9A-Fa-f]", "", value)
+    if len(compact) != 12:
+        return value.upper()
+
+    last_byte = int(compact[-2:], 16)
+    next_byte = (last_byte + delta) & 0xFF
+    compact = f"{compact[:-2]}{next_byte:02X}"
+    return ":".join(compact[i : i + 2] for i in range(0, 12, 2)).upper()
+
+
+class LocalBleAguaIOT:
+    """Micronova transport using the local BLE API exposed by the T009 module."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api_url: str,
+        customer_code: str,
+        email: str,
+        password: str,
+        unique_id: str,
+        *,
+        login_api_url: str | None = None,
+        brand_id: str | None = None,
+        brand: str | None = None,
+        application_version: str = "1.9.7",
+        async_client=None,
+        air_temp_fix: bool = False,
+        reading_error_fix: bool = False,
+        language: str | None = "ENG",
+        http_timeout: int | None = 30,
+        buffer_read_timeout: int | None = 30,
+        service_uuid: str = DEFAULT_SERVICE_UUID,
+        char_uuid: str = DEFAULT_CHAR_UUID,
+        cached_devices: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.hass = hass
+        self.api_url = api_url.rstrip("/")
+        self.customer_code = customer_code
+        self.email = email
+        self.password = password
+        self.unique_id = unique_id
+        self.login_api_url = login_api_url
+        self.brand_id = brand_id
+        self.brand = brand
+        self.application_version = application_version
+        self.async_client = async_client
+        self.air_temp_fix = air_temp_fix
+        self.reading_error_fix = reading_error_fix
+        self.language = language
+        self.http_timeout = http_timeout or 30
+        self.buffer_read_timeout = buffer_read_timeout or 30
+        self.service_uuid = service_uuid.lower()
+        self.char_uuid = char_uuid.lower()
+        self.devices: list[Device] = []
+
+        self._session_uuid = str(uuid.uuid4()).upper()
+        self._cached_devices = cached_devices or []
+        self._cache_dirty = False
+        self._command_lock = asyncio.Lock()
+
+    @property
+    def cache_dirty(self) -> bool:
+        """Return True when bootstrap cache should be persisted."""
+        return self._cache_dirty
+
+    def export_bootstrap_cache(self) -> list[dict[str, Any]]:
+        """Export device bootstrap data for config entry persistence."""
+        return [device.export_cache() for device in self.devices]
+
+    def mark_cache_persisted(self) -> None:
+        """Clear the dirty flag once bootstrap data is stored."""
+        self._cache_dirty = False
+
+    async def connect(self) -> None:
+        """Initialize devices from cache, or bootstrap once through the cloud API."""
+        if self._cached_devices:
+            self._load_cached_devices(self._cached_devices)
+            return
+
+        await self._bootstrap_from_cloud()
+
+    async def fetch_device_information(self) -> None:
+        """Compatibility helper with the cloud transport."""
+        for dev in self.devices:
+            await dev.update_mapping()
+
+    async def update(self) -> None:
+        """Refresh all devices using BLE."""
+        for dev in self.devices:
+            await dev.update()
+
+    async def _bootstrap_from_cloud(self) -> None:
+        """Fetch device metadata and register mappings once via the cloud API."""
+        cloud = aguaiot(
+            api_url=self.api_url,
+            customer_code=self.customer_code,
+            email=self.email,
+            password=self.password,
+            unique_id=self.unique_id,
+            login_api_url=self.login_api_url,
+            brand_id=self.brand_id,
+            brand=self.brand,
+            application_version=self.application_version,
+            async_client=self.async_client,
+            air_temp_fix=self.air_temp_fix,
+            reading_error_fix=self.reading_error_fix,
+            language=self.language,
+            http_timeout=self.http_timeout,
+            buffer_read_timeout=self.buffer_read_timeout,
+        )
+        await cloud.connect()
+
+        self.devices = [
+            Device(
+                dev.id,
+                dev.id_device,
+                dev.id_product,
+                dev.product_serial,
+                dev.name,
+                dev.is_online,
+                dev.name_product,
+                dev.id_registers_map,
+                self,
+                device_info=dev.device_info_data,
+                register_map=dev.export_register_map(),
+            )
+            for dev in cloud.devices
+        ]
+        self._cache_dirty = True
+
+    def _load_cached_devices(self, cached_devices: list[dict[str, Any]]) -> None:
+        """Restore devices from persisted bootstrap cache."""
+        self.devices = [
+            Device(
+                entry["id"],
+                entry["id_device"],
+                entry["id_product"],
+                entry["product_serial"],
+                entry["name"],
+                entry["is_online"],
+                entry["name_product"],
+                entry["id_registers_map"],
+                self,
+                device_info=entry.get("device_info"),
+                register_map=entry.get("register_map"),
+            )
+            for entry in cached_devices
+        ]
+
+    async def _fetch_device_registers_mapping(self, device: Device) -> dict[str, Any]:
+        """Return the cached registers map."""
+        register_map = device.export_register_map()
+        if register_map:
+            return register_map
+
+        raise AguaIOTError(
+            f"No cached register map available for '{device.name}'. Bootstrap through the cloud API first."
+        )
+
+    async def _fetch_device_information(self, device: Device) -> dict[int, int]:
+        """Read all current buffer values from the stove over BLE."""
+        async with self._device_session(device) as session:
+            await session.identity()
+            buffer_ids = await session.get_buffer_ids()
+            if not buffer_ids:
+                buffer_ids = [1]
+
+            info: dict[int, int] = {}
+            for buffer_id in buffer_ids:
+                response = await session.get_buffer_reading(buffer_id)
+                payload = response.get("pl", {})
+                items = payload.get("Items") or []
+                values = payload.get("Values") or []
+                if not isinstance(items, list) or not isinstance(values, list):
+                    continue
+
+                for idx, item in enumerate(items):
+                    if idx < len(values):
+                        info[item] = values[idx]
+
+            if not info:
+                raise AguaIOTUpdateError(
+                    f"Bluetooth read returned no register values for '{device.name}'."
+                )
+
+            return info
+
+    async def _request_writing(self, device: Device, items: dict[str, int]) -> None:
+        """Write raw register values to the stove over BLE."""
+        item_offsets = []
+        masks = []
+        bit_data = []
+        values = []
+
+        for key, value in items.items():
+            register = device.get_register(key)
+            mask = int(register["mask"])
+            item_offsets.append(int(register["offset"]))
+            masks.append(mask)
+            bit_data.append(16 if mask > 0xFF else 8)
+            values.append(value)
+
+        payload = {
+            "Cmd": "RequestWriting",
+            "Protocol": "RWMSmaster",
+            "BitData": bit_data,
+            "Endianess": ["L"] * len(item_offsets),
+            "Items": item_offsets,
+            "Masks": masks,
+            "Values": values,
+        }
+
+        async with self._device_session(device) as session:
+            await session.identity()
+            buffer_ids = await session.get_buffer_ids()
+            if buffer_ids:
+                # Prime the local session the same way the vendor app does:
+                # it reads buffers before sending writes.
+                await session.get_buffer_reading(buffer_ids[0])
+            response = await session.exchange(
+                self._make_enveloped_command(payload)
+            )
+            payload = response.get("pl", {})
+            if payload.get("NackErrCode") is not None:
+                raise AguaIOTError(
+                    f"Bluetooth write failed for '{device.name}' with NackErrCode={payload['NackErrCode']}"
+                )
+
+    def _device_identity_id(self, device: Device) -> str:
+        """Return the device id used by the local BLE protocol."""
+        value = _normalize_identity_id(device.ble_mac) or _normalize_identity_id(
+            device.product_serial
+        )
+        if not value:
+            raise AguaIOTError(
+                f"Missing BLE identity for '{device.name}'. Re-bootstrap the device from the cloud API."
+            )
+        return value
+
+    def _device_ble_address(self, device: Device) -> str:
+        """Return the BLE address to connect to."""
+        value = _normalize_ble_address(device.ble_mac)
+        if not value:
+            raise AguaIOTError(
+                f"Missing BLE address for '{device.name}'. Re-bootstrap the device from the cloud API."
+            )
+        return value
+
+    def _device_security_code(self, device: Device) -> str:
+        """Return the BLE security code."""
+        value = device.ble_security_code
+        if not value:
+            raise AguaIOTError(
+                f"Missing BLE security code for '{device.name}'. Re-bootstrap the device from the cloud API."
+            )
+        return str(value)
+
+    def _expected_local_name(self, device: Device) -> str | None:
+        """Return the expected T009 local name for the stove."""
+        identity = _normalize_identity_id(device.ble_mac)
+        if not identity or len(identity) < 6:
+            return None
+
+        return f"{DEFAULT_NAME_PREFIX}{identity[-6:]}"
+
+    def _candidate_ble_addresses(self, device: Device) -> list[str]:
+        """Return likely BLE addresses for the T009 module.
+
+        The cloud API exposes the base module MAC, while BLE advertisements on real
+        devices are often seen on adjacent addresses (for example `+2`).
+        """
+        address = self._device_ble_address(device)
+        candidates = [address]
+
+        for delta in (1, 2, 3):
+            candidate = _increment_ble_address(address, delta)
+            if candidate not in candidates:
+                candidates.append(candidate)
+
+        return candidates
+
+    def _make_enveloped_command(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Wrap a Micronova local payload in the JSON envelope used by the app."""
+        return {
+            "mt": "Q",
+            "s": {"ss": "Apk", "sj": self._session_uuid},
+            "r": {"rj": "Navel"},
+            "pl": payload,
+        }
+
+    def _make_identity_command(self, device: Device) -> dict[str, Any]:
+        """Build the local BLE identity command."""
+        return self._make_enveloped_command(
+            {
+                "Id": self._device_identity_id(device),
+                "Security": self._device_security_code(device),
+                "Cmd": "Identity",
+            }
+        )
+
+    async def _async_get_ble_device(self, device: Device):
+        """Resolve the target BLEDevice from Home Assistant's shared scanner."""
+        address = self._device_ble_address(device)
+        candidate_addresses = self._candidate_ble_addresses(device)
+        expected_name = self._expected_local_name(device)
+        scanner_count = bluetooth.async_scanner_count(self.hass, connectable=True)
+
+        if scanner_count == 0:
+            _LOGGER.warning(
+                "No connectable Bluetooth adapters are available in Home Assistant; "
+                "trying direct Bleak connection to %s for '%s'.",
+                address,
+                device.name,
+            )
+            return address
+
+        for connectable in (True, False):
+            for candidate_address in candidate_addresses:
+                ble_device = bluetooth.async_ble_device_from_address(
+                    self.hass,
+                    candidate_address,
+                    connectable=connectable,
+                )
+                if ble_device is not None:
+                    _LOGGER.debug(
+                        "Using BLEDevice for '%s' via address %s (connectable=%s): %s",
+                        device.name,
+                        candidate_address,
+                        connectable,
+                        ble_device,
+                    )
+                    return ble_device
+
+            fallback_prefix_device = None
+            for service_info in bluetooth.async_discovered_service_info(
+                self.hass, connectable=connectable
+            ):
+                service_address = service_info.address.upper()
+                service_name = (
+                    getattr(service_info, "name", None)
+                    or getattr(service_info.device, "name", None)
+                    or getattr(service_info.advertisement, "local_name", None)
+                    or ""
+                )
+
+                if service_address in candidate_addresses:
+                    _LOGGER.debug(
+                        "Matched BLE service info for '%s' by address %s (connectable=%s, name=%s)",
+                        device.name,
+                        service_address,
+                        connectable,
+                        service_name,
+                    )
+                    return service_info.device
+
+                if expected_name and service_name == expected_name:
+                    _LOGGER.debug(
+                        "Matched BLE service info for '%s' by exact name %s (address=%s, connectable=%s)",
+                        device.name,
+                        expected_name,
+                        service_address,
+                        connectable,
+                    )
+                    return service_info.device
+
+                if (
+                    fallback_prefix_device is None
+                    and service_name.startswith(DEFAULT_NAME_PREFIX)
+                ):
+                    fallback_prefix_device = service_info.device
+
+            if fallback_prefix_device is not None:
+                _LOGGER.debug(
+                    "Using fallback T009 BLE service info for '%s' (connectable=%s): %s",
+                    device.name,
+                    connectable,
+                    fallback_prefix_device,
+                )
+                return fallback_prefix_device
+
+        _LOGGER.warning(
+            "Micronova BLE device for '%s' was not discovered by Home Assistant; "
+            "trying direct Bleak connection to %s (candidates=%s, expected_name=%s).",
+            device.name,
+            address,
+            candidate_addresses,
+            expected_name,
+        )
+        return address
+
+    def _device_session(self, device: Device) -> "_BleMicronovaSession":
+        """Create a BLE session wrapper for one device."""
+        return _BleMicronovaSession(self, device)
+
+
+class _BleMicronovaSession:
+    """Single BLE session used for one read/write sequence."""
+
+    def __init__(self, transport: LocalBleAguaIOT, device: Device) -> None:
+        self._transport = transport
+        self._device = device
+        self._client: BleakClient | None = None
+        self._characteristic_uuid: str | None = None
+        self._response_ready = asyncio.Event()
+        self._notif_len: int | None = None
+
+    async def __aenter__(self) -> "_BleMicronovaSession":
+        await self._transport._command_lock.acquire()
+        ble_device = await self._transport._async_get_ble_device(self._device)
+
+        try:
+            self._client = await establish_connection(
+                BleakClientWithServiceCache,
+                ble_device,
+                self._device.name,
+                max_attempts=3,
+            )
+        except BleakError as err:
+            self._transport._command_lock.release()
+            raise AguaIOTConnectionError(
+                f"Bluetooth connection to '{self._device.name}' failed: {err}"
+            ) from err
+        except Exception as err:  # noqa: BLE001
+            self._transport._command_lock.release()
+            raise AguaIOTConnectionError(
+                f"Bluetooth connection to '{self._device.name}' failed: {err}"
+            ) from err
+
+        characteristic_uuid = self._resolve_characteristic_uuid()
+        self._characteristic_uuid = characteristic_uuid
+        await self._client.start_notify(characteristic_uuid, self._handle_notify)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        try:
+            if self._client and self._characteristic_uuid:
+                await self._client.stop_notify(self._characteristic_uuid)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Ignoring BLE stop_notify failure: %s", err)
+        finally:
+            try:
+                if self._client:
+                    await self._client.disconnect()
+            finally:
+                self._transport._command_lock.release()
+
+    def _resolve_characteristic_uuid(self) -> str:
+        """Pick the characteristic used as the JSON tunnel."""
+        assert self._client is not None
+        preferred = None
+        fallback = None
+
+        for service in self._client.services:
+            for characteristic in service.characteristics:
+                properties = {str(prop).lower() for prop in characteristic.properties}
+                if (
+                    service.uuid.lower() == self._transport.service_uuid
+                    and characteristic.uuid.lower() == self._transport.char_uuid
+                ):
+                    return characteristic.uuid
+
+                if {"write", "read"} <= properties and (
+                    "notify" in properties or "indicate" in properties
+                ):
+                    preferred = preferred or characteristic.uuid
+                elif "write" in properties and (
+                    "notify" in properties or "indicate" in properties
+                ):
+                    fallback = fallback or characteristic.uuid
+
+        if preferred:
+            return preferred
+        if fallback:
+            return fallback
+
+        raise AguaIOTConnectionError(
+            f"Could not find a suitable Micronova GATT characteristic on '{self._device.name}'."
+        )
+
+    def _handle_notify(self, _sender: Any, data: bytearray) -> None:
+        """Process the 2-byte 'response length ready' notification."""
+        self._notif_len = int.from_bytes(data[:2], "little") if len(data) >= 2 else None
+        self._response_ready.set()
+
+    async def identity(self) -> dict[str, Any]:
+        """Authenticate the BLE session."""
+        response = await self.exchange(self._transport._make_identity_command(self._device))
+        payload = response.get("pl", {})
+        if payload.get("NackErrCode") is not None:
+            raise AguaIOTError(
+                f"Bluetooth identity failed for '{self._device.name}' with NackErrCode={payload['NackErrCode']}"
+            )
+        return response
+
+    async def get_buffer_ids(self) -> list[int]:
+        """Return the list of available buffer ids."""
+        response = await self.exchange(
+            self._transport._make_enveloped_command({"Cmd": "GetBufferId"})
+        )
+        payload = response.get("pl", {})
+        indexes = payload.get("Indexes") or payload.get("indexes") or []
+        if isinstance(indexes, list):
+            return [int(idx) for idx in indexes]
+        return []
+
+    async def get_buffer_reading(self, buffer_id: int) -> dict[str, Any]:
+        """Read one Micronova buffer through BLE."""
+        return await self.exchange(
+            self._transport._make_enveloped_command(
+                {"Cmd": "GetBufferReading", "BufferId": int(buffer_id)}
+            )
+        )
+
+    async def exchange(self, command: dict[str, Any]) -> dict[str, Any]:
+        """Send one JSON command and return its JSON response."""
+        await self._write_json_message(command)
+        expected_len = None
+        cmd_name = command.get("pl", {}).get("Cmd")
+        notify_timeout = min(self._transport.buffer_read_timeout, 5)
+        try:
+            await asyncio.wait_for(
+                self._response_ready.wait(),
+                timeout=notify_timeout,
+            )
+            expected_len = self._notif_len
+        except asyncio.TimeoutError as err:
+            _LOGGER.debug(
+                "No BLE notification received for '%s' command '%s'; "
+                "falling back to direct characteristic read.",
+                self._device.name,
+                cmd_name,
+            )
+            if cmd_name != "RequestWriting":
+                raise AguaIOTUpdateError(
+                    f"Bluetooth response timeout while talking to '{self._device.name}'."
+                ) from err
+
+        response = await self._read_json_response(expected_len)
+        self._response_ready.clear()
+        self._notif_len = None
+        return response
+
+    async def _write_json_message(self, obj: dict[str, Any]) -> None:
+        """Send the Micronova binary header, then the JSON body."""
+        assert self._client is not None
+        assert self._characteristic_uuid is not None
+
+        body = json.dumps(obj, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        header = b"JSON" + struct.pack("<H", len(body)) + b"\xF9\x01"
+
+        self._response_ready.clear()
+        self._notif_len = None
+
+        await self._client.write_gatt_char(self._characteristic_uuid, header, response=True)
+
+        mtu = getattr(self._client, "mtu_size", 23) or 23
+        chunk_size = max(20, mtu - 3)
+        for index in range(0, len(body), chunk_size):
+            chunk = body[index : index + chunk_size]
+            await self._client.write_gatt_char(
+                self._characteristic_uuid,
+                chunk,
+                response=True,
+            )
+
+    async def _read_json_response(self, expected_len: int | None) -> dict[str, Any]:
+        """Read one or more chunks from the characteristic until the JSON body is complete."""
+        assert self._client is not None
+        assert self._characteristic_uuid is not None
+
+        if not expected_len or expected_len <= 0:
+            raw = await self._client.read_gatt_char(self._characteristic_uuid)
+            return _parse_json_response(bytes(raw))
+
+        data = bytearray()
+        last_chunk: bytes | None = None
+
+        for _ in range(32):
+            chunk = bytes(await self._client.read_gatt_char(self._characteristic_uuid))
+            if not chunk:
+                break
+            if chunk == last_chunk:
+                break
+            data.extend(chunk)
+            last_chunk = chunk
+            if len(data) >= expected_len:
+                break
+
+        if not data:
+            raise AguaIOTUpdateError(
+                f"Bluetooth read returned no data for '{self._device.name}'."
+            )
+
+        return _parse_json_response(bytes(data[:expected_len]))
+
+
+def _parse_json_response(raw: bytes) -> dict[str, Any]:
+    """Parse a BLE response that may optionally include the Micronova JSON header."""
+    if raw.startswith(b"JSON") and len(raw) >= 8:
+        body_len = struct.unpack_from("<H", raw, 4)[0]
+        raw = raw[8 : 8 + body_len]
+
+    first_json = raw.find(b"{")
+    if first_json != -1:
+        raw = raw[first_json:]
+
+    try:
+        return json.loads(raw.decode("utf-8", errors="ignore"))
+    except json.JSONDecodeError as err:
+        raise AguaIOTUpdateError(
+            f"Invalid JSON received from the Micronova BLE transport: {raw[:80]!r}"
+        ) from err

--- a/custom_components/aguaiot/local_ble.py
+++ b/custom_components/aguaiot/local_ble.py
@@ -30,6 +30,14 @@ DEFAULT_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
 DEFAULT_NAME_PREFIX = "T009_"
 
 
+def _is_ble_authorization_error(err: Exception) -> bool:
+    """Return True when the BLE stack rejected the link for authorization reasons."""
+    message = str(err).lower()
+    return "insufficient authorization" in message or (
+        "authorization" in message and "(8)" in message
+    )
+
+
 def _normalize_ble_address(value: str | None) -> str | None:
     """Return a colon-separated BLE address."""
     if not value:
@@ -156,31 +164,19 @@ class LocalBleAguaIOT:
             )
 
         device = self.devices[0]
-        async with self._device_session(device) as session:
-            await session.identity()
-            buffer_ids = await session.get_buffer_ids()
-            if not buffer_ids:
-                raise AguaIOTUpdateError(
-                    f"Bluetooth validation succeeded but no buffer IDs were returned for '{device.name}'."
-                )
-
-            await session.get_buffer_reading(buffer_ids[0])
-            result = {
-                "device_name": device.name,
-                "module_address": session.connected_address
-                or self._device_ble_address(device),
-                "module_name": session.connected_name
-                or self._expected_local_name(device),
-                "buffer_ids": buffer_ids,
-            }
-            _LOGGER.info(
-                "Validated Micronova BLE module for '%s' via %s (%s), buffer_ids=%s",
-                device.name,
-                result["module_address"],
-                result["module_name"],
-                buffer_ids,
-            )
-            return result
+        result = await self._run_authenticated_session(
+            device,
+            "validating the local Bluetooth connection",
+            self._validate_local_connection_session,
+        )
+        _LOGGER.info(
+            "Validated Micronova BLE module for '%s' via %s (%s), buffer_ids=%s",
+            device.name,
+            result["module_address"],
+            result["module_name"],
+            result["buffer_ids"],
+        )
+        return result
 
     async def _bootstrap_from_cloud(self) -> None:
         """Fetch device metadata and register mappings once via the cloud API."""
@@ -252,31 +248,11 @@ class LocalBleAguaIOT:
 
     async def _fetch_device_information(self, device: Device) -> dict[int, int]:
         """Read all current buffer values from the stove over BLE."""
-        async with self._device_session(device) as session:
-            await session.identity()
-            buffer_ids = await session.get_buffer_ids()
-            if not buffer_ids:
-                buffer_ids = [1]
-
-            info: dict[int, int] = {}
-            for buffer_id in buffer_ids:
-                response = await session.get_buffer_reading(buffer_id)
-                payload = response.get("pl", {})
-                items = payload.get("Items") or []
-                values = payload.get("Values") or []
-                if not isinstance(items, list) or not isinstance(values, list):
-                    continue
-
-                for idx, item in enumerate(items):
-                    if idx < len(values):
-                        info[item] = values[idx]
-
-            if not info:
-                raise AguaIOTUpdateError(
-                    f"Bluetooth read returned no register values for '{device.name}'."
-                )
-
-            return info
+        return await self._run_authenticated_session(
+            device,
+            "reading device information",
+            self._fetch_device_information_session,
+        )
 
     async def _request_writing(self, device: Device, items: dict[str, int]) -> None:
         """Write raw register values to the stove over BLE."""
@@ -303,19 +279,106 @@ class LocalBleAguaIOT:
             "Values": values,
         }
 
-        async with self._device_session(device) as session:
-            await session.identity()
-            buffer_ids = await session.get_buffer_ids()
-            if buffer_ids:
-                # Prime the local session the same way the vendor app does:
-                # it reads buffers before sending writes.
-                await session.get_buffer_reading(buffer_ids[0])
-            response = await session.exchange(self._make_enveloped_command(payload))
+        await self._run_authenticated_session(
+            device,
+            "writing stove registers",
+            lambda session: self._request_writing_session(session, payload),
+        )
+
+    async def _validate_local_connection_session(
+        self, session: "_BleMicronovaSession"
+    ) -> dict[str, Any]:
+        """Validate the BLE tunnel through an authenticated session."""
+        buffer_ids = await session.get_buffer_ids()
+        if not buffer_ids:
+            raise AguaIOTUpdateError(
+                f"Bluetooth validation succeeded but no buffer IDs were returned for '{session._device.name}'."
+            )
+
+        await session.get_buffer_reading(buffer_ids[0])
+        return {
+            "device_name": session._device.name,
+            "module_address": session.connected_address
+            or self._device_ble_address(session._device),
+            "module_name": session.connected_name
+            or self._expected_local_name(session._device),
+            "buffer_ids": buffer_ids,
+        }
+
+    async def _fetch_device_information_session(
+        self, session: "_BleMicronovaSession"
+    ) -> dict[int, int]:
+        """Read all current buffer values through an authenticated session."""
+        buffer_ids = await session.get_buffer_ids()
+        if not buffer_ids:
+            buffer_ids = [1]
+
+        info: dict[int, int] = {}
+        for buffer_id in buffer_ids:
+            response = await session.get_buffer_reading(buffer_id)
             payload = response.get("pl", {})
-            if payload.get("NackErrCode") is not None:
-                raise AguaIOTError(
-                    f"Bluetooth write failed for '{device.name}' with NackErrCode={payload['NackErrCode']}"
-                )
+            items = payload.get("Items") or []
+            values = payload.get("Values") or []
+            if not isinstance(items, list) or not isinstance(values, list):
+                continue
+
+            for idx, item in enumerate(items):
+                if idx < len(values):
+                    info[item] = values[idx]
+
+        if not info:
+            raise AguaIOTUpdateError(
+                f"Bluetooth read returned no register values for '{session._device.name}'."
+            )
+
+        return info
+
+    async def _request_writing_session(
+        self, session: "_BleMicronovaSession", payload: dict[str, Any]
+    ) -> None:
+        """Write raw register values through an authenticated session."""
+        buffer_ids = await session.get_buffer_ids()
+        if buffer_ids:
+            # Prime the local session the same way the vendor app does:
+            # it reads buffers before sending writes.
+            await session.get_buffer_reading(buffer_ids[0])
+        response = await session.exchange(self._make_enveloped_command(payload))
+        response_payload = response.get("pl", {})
+        if response_payload.get("NackErrCode") is not None:
+            raise AguaIOTError(
+                f"Bluetooth write failed for '{session._device.name}' with NackErrCode={response_payload['NackErrCode']}"
+            )
+
+    async def _run_authenticated_session(
+        self,
+        device: Device,
+        action: str,
+        operation,
+    ) -> Any:
+        """Run one BLE action with a single retry on lost authorization."""
+        for attempt in range(2):
+            try:
+                async with self._device_session(device) as session:
+                    await session.identity()
+                    return await operation(session)
+            except (BleakError, AguaIOTConnectionError) as err:
+                if not _is_ble_authorization_error(err):
+                    raise
+
+                if attempt == 0:
+                    _LOGGER.warning(
+                        "Micronova BLE link for '%s' lost authorization while %s; retrying once with a fresh connection.",
+                        device.name,
+                        action,
+                    )
+                    await asyncio.sleep(0.5)
+                    continue
+
+                raise AguaIOTConnectionError(
+                    f"Bluetooth connection to '{device.name}' lost authorization while {action}. "
+                    "The Navel/T009 module or Bluetooth proxy dropped its authorized GATT state; "
+                    "reloading the integration or resetting the BLE module may be required."
+                ) from err
 
     def _device_identity_id(self, device: Device) -> str:
         """Return the device id used by the local BLE protocol."""

--- a/custom_components/aguaiot/local_ble.py
+++ b/custom_components/aguaiot/local_ble.py
@@ -142,6 +142,37 @@ class LocalBleAguaIOT:
         for dev in self.devices:
             await dev.update()
 
+    async def validate_local_connection(self) -> dict[str, Any]:
+        """Detect and validate the local BLE module for the first configured stove."""
+        if not self.devices:
+            raise AguaIOTError("No Micronova devices are available for local Bluetooth.")
+
+        device = self.devices[0]
+        async with self._device_session(device) as session:
+            await session.identity()
+            buffer_ids = await session.get_buffer_ids()
+            if not buffer_ids:
+                raise AguaIOTUpdateError(
+                    f"Bluetooth validation succeeded but no buffer IDs were returned for '{device.name}'."
+                )
+
+            await session.get_buffer_reading(buffer_ids[0])
+            result = {
+                "device_name": device.name,
+                "module_address": session.connected_address
+                or self._device_ble_address(device),
+                "module_name": session.connected_name or self._expected_local_name(device),
+                "buffer_ids": buffer_ids,
+            }
+            _LOGGER.info(
+                "Validated Micronova BLE module for '%s' via %s (%s), buffer_ids=%s",
+                device.name,
+                result["module_address"],
+                result["module_name"],
+                buffer_ids,
+            )
+            return result
+
     async def _bootstrap_from_cloud(self) -> None:
         """Fetch device metadata and register mappings once via the cloud API."""
         cloud = aguaiot(
@@ -456,10 +487,12 @@ class _BleMicronovaSession:
         self._characteristic_uuid: str | None = None
         self._response_ready = asyncio.Event()
         self._notif_len: int | None = None
+        self._resolved_target: Any = None
 
     async def __aenter__(self) -> "_BleMicronovaSession":
         await self._transport._command_lock.acquire()
         ble_device = await self._transport._async_get_ble_device(self._device)
+        self._resolved_target = ble_device
 
         try:
             self._client = await establish_connection(
@@ -496,6 +529,32 @@ class _BleMicronovaSession:
                     await self._client.disconnect()
             finally:
                 self._transport._command_lock.release()
+
+    @property
+    def connected_address(self) -> str | None:
+        """Return the resolved BLE address for the session."""
+        if self._client and getattr(self._client, "address", None):
+            return str(self._client.address).upper()
+
+        if isinstance(self._resolved_target, str):
+            return self._resolved_target.upper()
+
+        if self._resolved_target is not None and getattr(self._resolved_target, "address", None):
+            return str(self._resolved_target.address).upper()
+
+        return None
+
+    @property
+    def connected_name(self) -> str | None:
+        """Return the resolved BLE local name for the session."""
+        if self._resolved_target is None:
+            return None
+
+        if isinstance(self._resolved_target, str):
+            return None
+
+        name = getattr(self._resolved_target, "name", None)
+        return str(name) if name else None
 
     def _resolve_characteristic_uuid(self) -> str:
         """Pick the characteristic used as the JSON tunnel."""

--- a/custom_components/aguaiot/local_ble.py
+++ b/custom_components/aguaiot/local_ble.py
@@ -28,6 +28,8 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
 DEFAULT_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
 DEFAULT_NAME_PREFIX = "T009_"
+BLE_DISCOVERY_RETRY_INTERVAL = 1
+BLE_DISCOVERY_MAX_WAIT = 30
 
 
 def _is_ble_authorization_error(err: Exception) -> bool:
@@ -452,21 +454,19 @@ class LocalBleAguaIOT:
             }
         )
 
-    async def _async_get_ble_device(self, device: Device):
-        """Resolve the target BLEDevice from Home Assistant's shared scanner."""
+    def _find_ble_device(self, device: Device) -> tuple[Any | None, str]:
+        """Find the target BLEDevice in Home Assistant's shared scanner."""
         address = self._device_ble_address(device)
         candidate_addresses = self._candidate_ble_addresses(device)
         expected_name = self._expected_local_name(device)
         scanner_count = bluetooth.async_scanner_count(self.hass, connectable=True)
 
         if scanner_count == 0:
-            _LOGGER.warning(
-                "No connectable Bluetooth adapters are available in Home Assistant; "
-                "trying direct Bleak connection to %s for '%s'.",
-                address,
-                device.name,
+            return (
+                None,
+                "No connectable Bluetooth adapters or ESPHome Bluetooth proxies are "
+                f"available in Home Assistant for '{device.name}'",
             )
-            return address
 
         for connectable in (True, False):
             for candidate_address in candidate_addresses:
@@ -483,7 +483,7 @@ class LocalBleAguaIOT:
                         connectable,
                         ble_device,
                     )
-                    return ble_device
+                    return ble_device, ""
 
             fallback_prefix_device = None
             for service_info in bluetooth.async_discovered_service_info(
@@ -505,7 +505,7 @@ class LocalBleAguaIOT:
                         connectable,
                         service_name,
                     )
-                    return service_info.device
+                    return service_info.device, ""
 
                 if expected_name and service_name == expected_name:
                     _LOGGER.debug(
@@ -515,7 +515,7 @@ class LocalBleAguaIOT:
                         service_address,
                         connectable,
                     )
-                    return service_info.device
+                    return service_info.device, ""
 
                 if fallback_prefix_device is None and service_name.startswith(
                     DEFAULT_NAME_PREFIX
@@ -529,17 +529,44 @@ class LocalBleAguaIOT:
                     connectable,
                     fallback_prefix_device,
                 )
-                return fallback_prefix_device
+                return fallback_prefix_device, ""
 
-        _LOGGER.warning(
-            "Micronova BLE device for '%s' was not discovered by Home Assistant; "
-            "trying direct Bleak connection to %s (candidates=%s, expected_name=%s).",
-            device.name,
-            address,
-            candidate_addresses,
-            expected_name,
+        return (
+            None,
+            f"Micronova BLE device for '{device.name}' was not discovered by Home "
+            f"Assistant yet (address={address}, candidates={candidate_addresses}, "
+            f"expected_name={expected_name})",
         )
-        return address
+
+    async def _async_get_ble_device(self, device: Device) -> Any:
+        """Resolve the target BLEDevice from Home Assistant's shared scanner."""
+        loop = asyncio.get_running_loop()
+        wait_seconds = min(max(self.buffer_read_timeout, 10), BLE_DISCOVERY_MAX_WAIT)
+        deadline = loop.time() + wait_seconds
+        logged_wait = False
+        last_reason = ""
+
+        while True:
+            ble_device, reason = self._find_ble_device(device)
+            if ble_device is not None:
+                return ble_device
+
+            last_reason = reason
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise AguaIOTConnectionError(
+                    f"{last_reason}. Home Assistant will retry once Bluetooth is ready."
+                )
+
+            if not logged_wait:
+                _LOGGER.info(
+                    "%s; waiting up to %s seconds before failing this update.",
+                    last_reason,
+                    int(wait_seconds),
+                )
+                logged_wait = True
+
+            await asyncio.sleep(min(BLE_DISCOVERY_RETRY_INTERVAL, remaining))
 
     def _device_session(self, device: Device) -> "_BleMicronovaSession":
         """Create a BLE session wrapper for one device."""
@@ -560,31 +587,42 @@ class _BleMicronovaSession:
 
     async def __aenter__(self) -> "_BleMicronovaSession":
         await self._transport._command_lock.acquire()
-        ble_device = await self._transport._async_get_ble_device(self._device)
-        self._resolved_target = ble_device
 
         try:
+            ble_device = await self._transport._async_get_ble_device(self._device)
+            self._resolved_target = ble_device
             self._client = await establish_connection(
                 BleakClientWithServiceCache,
                 ble_device,
                 self._device.name,
                 max_attempts=3,
             )
+            characteristic_uuid = self._resolve_characteristic_uuid()
+            self._characteristic_uuid = characteristic_uuid
+            await self._client.start_notify(characteristic_uuid, self._handle_notify)
+        except AguaIOTConnectionError:
+            await self._cleanup_failed_enter()
+            raise
         except BleakError as err:
-            self._transport._command_lock.release()
+            await self._cleanup_failed_enter()
             raise AguaIOTConnectionError(
                 f"Bluetooth connection to '{self._device.name}' failed: {err}"
             ) from err
         except Exception as err:  # noqa: BLE001
-            self._transport._command_lock.release()
+            await self._cleanup_failed_enter()
             raise AguaIOTConnectionError(
                 f"Bluetooth connection to '{self._device.name}' failed: {err}"
             ) from err
 
-        characteristic_uuid = self._resolve_characteristic_uuid()
-        self._characteristic_uuid = characteristic_uuid
-        await self._client.start_notify(characteristic_uuid, self._handle_notify)
         return self
+
+    async def _cleanup_failed_enter(self) -> None:
+        """Disconnect and release the command lock after a failed enter."""
+        try:
+            if self._client:
+                await self._client.disconnect()
+        finally:
+            self._transport._command_lock.release()
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
         try:

--- a/custom_components/aguaiot/manifest.json
+++ b/custom_components/aguaiot/manifest.json
@@ -3,7 +3,7 @@
   "name": "Micronova Agua IOT",
   "codeowners": ["@vincentwolsink"],
   "config_flow": true,
-  "dependencies": [],
+  "dependencies": ["bluetooth"],
   "documentation": "https://github.com/vincentwolsink/home_assistant_micronova_agua_iot/",
   "integration_type": "hub",
   "iot_class": "cloud_polling",  

--- a/custom_components/aguaiot/strings.json
+++ b/custom_components/aguaiot/strings.json
@@ -33,16 +33,15 @@
     "step": {
       "user": {
         "title": "Micronova Agua IOT options",
+        "description": "Select `Bluetooth local` to let Home Assistant auto-detect and validate a nearby Micronova BLE module when you submit the form.",
         "data": {
           "air_temp_fix": "[Jolly Mec] Ignore incorrect air temperature when using external themostat.",
-                "reading_error_fix": "[Bronpi] Filter incorrect readings (when stove is without power).",
-                "http_timeout": "Timeout for API calls (seconds).",
-                "buffer_read_timeout": "Timeout for stove buffer reading (seconds).",
-                "connection_mode": "Connection mode.",
-                "ble_service_uuid": "Bluetooth service UUID.",
-                "ble_char_uuid": "Bluetooth characteristic UUID.",
-                "language": "Language for descriptions.",
-                "update_interval": "Time between updates (seconds)."
+          "reading_error_fix": "[Bronpi] Filter incorrect readings (when stove is without power).",
+          "http_timeout": "Timeout for API calls (seconds).",
+          "buffer_read_timeout": "Timeout for stove buffer reading (seconds).",
+          "connection_mode": "Connection mode.",
+          "language": "Language for descriptions.",
+          "update_interval": "Time between updates (seconds)."
         }
       }
     }

--- a/custom_components/aguaiot/strings.json
+++ b/custom_components/aguaiot/strings.json
@@ -35,11 +35,14 @@
         "title": "Micronova Agua IOT options",
         "data": {
           "air_temp_fix": "[Jolly Mec] Ignore incorrect air temperature when using external themostat.",
-          "reading_error_fix": "[Bronpi] Filter incorrect readings (when stove is without power).",
-          "http_timeout": "Timeout for API calls (seconds).",
-          "buffer_read_timeout": "Timeout for stove buffer reading (seconds).",
-          "language": "Language for descriptions.",
-          "update_interval": "Time between updates (seconds)."
+                "reading_error_fix": "[Bronpi] Filter incorrect readings (when stove is without power).",
+                "http_timeout": "Timeout for API calls (seconds).",
+                "buffer_read_timeout": "Timeout for stove buffer reading (seconds).",
+                "connection_mode": "Connection mode.",
+                "ble_service_uuid": "Bluetooth service UUID.",
+                "ble_char_uuid": "Bluetooth characteristic UUID.",
+                "language": "Language for descriptions.",
+                "update_interval": "Time between updates (seconds)."
         }
       }
     }

--- a/custom_components/aguaiot/translations/en.json
+++ b/custom_components/aguaiot/translations/en.json
@@ -29,14 +29,13 @@
         "step": {
             "user": {
                 "title": "Micronova Agua IOT options",
+                "description": "Select `Bluetooth local` to let Home Assistant auto-detect and validate a nearby Micronova BLE module when you submit the form.",
                 "data": {
                     "air_temp_fix": "[Jolly Mec] Ignore incorrect air temperature when using external themostat.",
                     "reading_error_fix": "[Bronpi] Filter incorrect readings (when stove is without power).",
                     "http_timeout": "Timeout for API calls (seconds).",
                     "buffer_read_timeout": "Timeout for stove buffer reading (seconds).",
                     "connection_mode": "Connection mode.",
-                    "ble_service_uuid": "Bluetooth service UUID.",
-                    "ble_char_uuid": "Bluetooth characteristic UUID.",
                     "language": "Language for descriptions.",
                     "update_interval": "Time between updates (seconds)."
                 }

--- a/custom_components/aguaiot/translations/en.json
+++ b/custom_components/aguaiot/translations/en.json
@@ -34,6 +34,9 @@
                     "reading_error_fix": "[Bronpi] Filter incorrect readings (when stove is without power).",
                     "http_timeout": "Timeout for API calls (seconds).",
                     "buffer_read_timeout": "Timeout for stove buffer reading (seconds).",
+                    "connection_mode": "Connection mode.",
+                    "ble_service_uuid": "Bluetooth service UUID.",
+                    "ble_char_uuid": "Bluetooth characteristic UUID.",
                     "language": "Language for descriptions.",
                     "update_interval": "Time between updates (seconds)."
                 }

--- a/custom_components/aguaiot/translations/fr.json
+++ b/custom_components/aguaiot/translations/fr.json
@@ -32,7 +32,13 @@
                 "data": {
                     "air_temp_fix": "[Jolly Mec] Ignorer la température de l'air incorrecte lors de l'utilisation d'un thermostat externe.",
                     "reading_error_fix": "[Bronpi] Filtrer les lectures incorrectes (lorsque le poêle est sans alimentation).",
-                    "language": "Langue pour les descriptions"
+                    "http_timeout": "Délai d'attente des appels API (secondes).",
+                    "buffer_read_timeout": "Délai d'attente des lectures du poêle (secondes).",
+                    "connection_mode": "Mode de connexion.",
+                    "ble_service_uuid": "UUID du service Bluetooth.",
+                    "ble_char_uuid": "UUID de la caractéristique Bluetooth.",
+                    "language": "Langue pour les descriptions",
+                    "update_interval": "Temps entre les mises à jour (secondes)."
                 }
             }
         }

--- a/custom_components/aguaiot/translations/fr.json
+++ b/custom_components/aguaiot/translations/fr.json
@@ -29,14 +29,13 @@
         "step": {
             "user": {
                 "title": "Options Micronova Agua IOT",
+                "description": "Sélectionnez `Bluetooth local` pour laisser Home Assistant détecter et valider automatiquement un module BLE Micronova à proximité lors de l'envoi du formulaire.",
                 "data": {
                     "air_temp_fix": "[Jolly Mec] Ignorer la température de l'air incorrecte lors de l'utilisation d'un thermostat externe.",
                     "reading_error_fix": "[Bronpi] Filtrer les lectures incorrectes (lorsque le poêle est sans alimentation).",
                     "http_timeout": "Délai d'attente des appels API (secondes).",
                     "buffer_read_timeout": "Délai d'attente des lectures du poêle (secondes).",
                     "connection_mode": "Mode de connexion.",
-                    "ble_service_uuid": "UUID du service Bluetooth.",
-                    "ble_char_uuid": "UUID de la caractéristique Bluetooth.",
                     "language": "Langue pour les descriptions",
                     "update_interval": "Temps entre les mises à jour (secondes)."
                 }


### PR DESCRIPTION
## Summary
- add an experimental `Bluetooth local` connection mode alongside the existing cloud mode
- add a Micronova BLE transport for local reads and writes through Home Assistant Bluetooth adapters / proxies
- persist the BLE bootstrap metadata in the config entry after the initial cloud bootstrap
- simplify the options flow so users can switch to local Bluetooth without dealing with BLE UUIDs
- document the local BLE flow, limitations, and tested hardware in the README
- treat alarm-like stove states as `off` in the climate entity so Home Assistant does not report `heating` during manual-alarm / final-cleaning style states

## How it works
This keeps the current cloud setup flow, then lets the user switch the integration options to `Bluetooth local`.

On submit, the integration performs a real local BLE validation before accepting the option:
- detect the nearby Micronova `T009_*` / Navel BLE module through Home Assistant Bluetooth
- connect to it
- authenticate with `Identity`
- read `GetBufferId` and one `GetBufferReading`

The local transport talks to the Micronova BLE module with the command family used by the vendor app:
- `Identity`
- `GetBufferId`
- `GetBufferReading`
- `RequestWriting`

The first bootstrap still uses the Micronova cloud API to learn the data needed for local control:
- device BLE identity / MAC reference
- BLE security code
- register map

Once that metadata is cached in Home Assistant, normal reads and writes can run locally over Bluetooth through Home Assistant's Bluetooth stack.

## Validation
Validated on the following installation:
- vendor app: `Jolly Mec Wi Fi`
- stove / insert model string: `SYNTHESIS/1/80/M`
- user-facing model reference: `Jolly Mec Modular Synthesis 80`
- local BLE module advertising as `T009_*`
- Bluetooth connectivity provided by Home Assistant ESPHome Bluetooth proxies

Validated locally on that installation:
- successful save of the `Bluetooth local` option with BLE validation enabled in the flow
- read current air temperature, smoke temperature, status, and alarm state
- switch between cloud mode and local Bluetooth mode
- start the stove from `off`
- change the target temperature
- change the main fan / power setting

## Notes
- this mode is intentionally documented as experimental
- no guarantee is made for every Micronova-based stove or every vendor app already supported by the integration
- feedback from other hardware / firmware combinations would be very useful
