### PR TITLE
Avoid BlueZ MTU warning in BLE transport

### DIFF
--- a/custom_components/aguaiot/local_ble.py
+++ b/custom_components/aguaiot/local_ble.py
@@ -30,6 +30,7 @@ DEFAULT_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
 DEFAULT_NAME_PREFIX = "T009_"
 BLE_DISCOVERY_RETRY_INTERVAL = 1
 BLE_DISCOVERY_MAX_WAIT = 30
+BLE_DEFAULT_PAYLOAD_SIZE = 20
 
 
 def _is_ble_authorization_error(err: Exception) -> bool:
@@ -780,10 +781,12 @@ class _BleMicronovaSession:
             self._characteristic_uuid, header, response=True
         )
 
-        mtu = getattr(self._client, "mtu_size", 23) or 23
-        chunk_size = max(20, mtu - 3)
-        for index in range(0, len(body), chunk_size):
-            chunk = body[index : index + chunk_size]
+        # Use the ATT payload size guaranteed by the default BLE MTU.
+        # Reading BleakClient.mtu_size on BlueZ emits a warning unless BlueZ-specific
+        # MTU acquisition was performed, and the warning can hide the real error in
+        # Home Assistant logs. The Micronova tunnel works with safe 20-byte chunks.
+        for index in range(0, len(body), BLE_DEFAULT_PAYLOAD_SIZE):
+            chunk = body[index : index + BLE_DEFAULT_PAYLOAD_SIZE]
             await self._client.write_gatt_char(
                 self._characteristic_uuid,
                 chunk,


### PR DESCRIPTION
## Summary
- avoid reading BleakClient.mtu_size in the local BLE transport
- always use safe 20-byte BLE JSON body chunks, matching the default ATT payload size
- prevents BlueZ/Bleak from emitting the noisy default-MTU warning that can obscure the real failure in Home Assistant logs

## Testing
- python3 -m compileall custom_components/aguaiot/local_ble.py

## Notes
This should remove the warning reported by a user testing Cadel Wall 3 Plus and Kobe 11 stoves. If their connection still fails after this patch, the logs should expose the real exception instead of being truncated around the warning.