### PR TITLE
Accept NAVEL_ BLE local-name prefix (Micronova/MCZ newer modules)

### DIFF
--- a/custom_components/aguaiot/local_ble.py
+++ b/custom_components/aguaiot/local_ble.py
@@ -28,6 +28,9 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_SERVICE_UUID = "6e400001-b5a3-f393-e0a9-e50e24dcca9e"
 DEFAULT_CHAR_UUID = "6e400002-b5a3-f393-e0a9-e50e24dcca9e"
 DEFAULT_NAME_PREFIX = "T009_"
+# Newer Micronova/MCZ BLE modules advertise as NAVEL_<suffix> instead of T009_<suffix>.
+# The suffix (last 6 chars of the MAC) is identical, only the family prefix changes.
+LOCAL_NAME_PREFIXES = ("T009_", "NAVEL_")
 BLE_DISCOVERY_RETRY_INTERVAL = 1
 BLE_DISCOVERY_MAX_WAIT = 30
 BLE_DEFAULT_PAYLOAD_SIZE = 20
@@ -562,10 +565,18 @@ class LocalBleAguaIOT:
                     )
                     return service_info.device, ""
 
-                if expected_name and service_name == expected_name:
+                if expected_name and (
+                    service_name == expected_name
+                    or (
+                        len(expected_name) >= 6
+                        and service_name.endswith(expected_name[-6:])
+                        and service_name.startswith(LOCAL_NAME_PREFIXES)
+                    )
+                ):
                     _LOGGER.debug(
-                        "Matched BLE service info for '%s' by exact name %s (address=%s, connectable=%s)",
+                        "Matched BLE service info for '%s' by name %s (expected=%s, address=%s, connectable=%s)",
                         device.name,
+                        service_name,
                         expected_name,
                         service_address,
                         connectable,
@@ -573,7 +584,7 @@ class LocalBleAguaIOT:
                     return service_info.device, ""
 
                 if fallback_prefix_device is None and service_name.startswith(
-                    DEFAULT_NAME_PREFIX
+                    LOCAL_NAME_PREFIXES
                 ):
                     fallback_prefix_device = service_info.device
 


### PR DESCRIPTION
## Summary

Newer Micronova/MCZ BLE modules advertise their local name as `NAVEL_<suffix>` instead of `T009_<suffix>`, while keeping the same MAC-derived 6-character suffix. Address-based discovery still works for them, but the name-based matching path in `_find_ble_device` (used both as an explicit-name match and as a prefix-only fallback) rejects these advertisements — which causes BLE recovery to fail when the address-based path doesn't return a `BLEDevice` (e.g. the address candidate window doesn't cover the actual advertised address, or HA's address tracking has expired between cycles).

Real-world impact:

* My own poêle MCZ (Easy Connect Plus) advertises as `NAVEL_BB731C` on . After 1.1.x my local BLE setup wedged because the `bluetooth_proxy` on the ESP32 went into safe mode for ~1 h; address tracking expired, the integration fell back to the name match, and the name match rejected the NAVEL prefix.
* Same symptom is described by another user on a Cadel Cristal 9 in #287 (`NAVEL_6651E8` advertised, integration expects `T009_6651E8`).

## Change

* Add `LOCAL_NAME_PREFIXES = ("T009_", "NAVEL_")`.
* In `_find_ble_device`, accept a service info as a match if its name starts with one of the known prefixes and ends with the expected 6-char suffix (the suffix is derived from the BLE MAC, identical between T009 and NAVEL).
* Extend the prefix-only fallback to accept either prefix.

`DEFAULT_NAME_PREFIX = \"T009_\"` and `_expected_local_name` are kept as-is so existing T009 logs and behavior are unchanged.

## Test plan

* [x] Patched on my running 1.1.2 setup → integration immediately reconnects to the `NAVEL_BB731C` module via the ESP32 BLE proxy, coordinator update succeeds.
* [ ] T009 setups: no behavior change expected (prefix list still includes `T009_`, expected_name still built with `T009_`).

Closes #287.