### PR TITLE
Tolerate transient connection errors in the data coordinator

### DIFF
--- a/custom_components/aguaiot/coordinator.py
+++ b/custom_components/aguaiot/coordinator.py
@@ -64,6 +64,12 @@ class AguaIOTDataUpdateCoordinator(DataUpdateCoordinator):
             config_entry=config_entry,
         )
 
+        # Tolerate this many consecutive transient connection errors before
+        # marking entities unavailable. Avoids flapping during the short BLE
+        # drops that are common on Micronova/Navel modules (issue #281).
+        self._consecutive_failures: int = 0
+        self._failure_tolerance: int = 3
+
         """Set up AguaIOT entry."""
         api_url = config_entry.data[CONF_API_URL]
         customer_code = config_entry.data[CONF_CUSTOMER_CODE]
@@ -133,12 +139,26 @@ class AguaIOTDataUpdateCoordinator(DataUpdateCoordinator):
         try:
             await self.agua.update()
             await self._async_persist_ble_bootstrap_if_needed()
+            self._consecutive_failures = 0
         except AguaIOTUpdateError as e:
             _LOGGER.error("Agua IOT Update error: %s", e)
         except AguaIOTUnauthorized as e:
             raise UpdateFailed(f"Agua IOT Unauthorized: {e}") from e
         except AguaIOTConnectionError as e:
-            raise UpdateFailed(f"Agua IOT Connection error: {e}") from e
+            self._consecutive_failures += 1
+            if self._consecutive_failures < self._failure_tolerance:
+                _LOGGER.warning(
+                    "Agua IOT transient connection error (%d/%d): %s. "
+                    "Keeping last known state.",
+                    self._consecutive_failures,
+                    self._failure_tolerance,
+                    e,
+                )
+                return
+            raise UpdateFailed(
+                f"Agua IOT Connection error after "
+                f"{self._consecutive_failures} retries: {e}"
+            ) from e
         except AguaIOTError as e:
             raise UpdateFailed(f"Agua IOT error: {e}") from e
 


### PR DESCRIPTION
## Summary

Single failed updates immediately flag every aguaiot entity as `unavailable`, even though the underlying BLE drops are typically very short and the next update succeeds. The result is constant flapping of the climate / sensor entities — a single missed buffer read, a notify timeout, or a brief BlueZ cache miss makes the whole device disappear from the UI for a cycle.

This is the symptom reported in #281 (\"It's not very steady\") and visible on my own setup (Micronova/MCZ Easy Connect Plus, `NAVEL_*` module, ESP32 BLE proxy < 1 m): with `update_interval=30s` the entity goes through `unavailable` every 30–60 minutes for ~1–3 minutes. The integration does recover on its own — the user just sees holes in the data.

## Change

* Add `_consecutive_failures` / `_failure_tolerance` (default 3) on the coordinator.
* In `_async_update_data`, on `AguaIOTConnectionError`: increment the counter and log a warning; only raise `UpdateFailed` once `_failure_tolerance` consecutive failures have happened.
* Successful updates reset the counter.

With the default `update_interval=60s` and tolerance=3, a temporary BLE drop of up to ~3 minutes is hidden from the user; longer outages still mark the entities as unavailable as before. Auth errors, generic `AguaIOTError`, and the existing `AguaIOTUpdateError` branch are deliberately unchanged — only the transient connection failure path is softened.

No new config option is introduced; if upstream prefers to expose the tolerance to users, it can be wired through `config_entry.options` later.

## Test plan

* [x] Applied on my running 1.1.2 instance with `update_interval=120s` and tolerance=3. Coordinator log now emits `Agua IOT transient connection error (1/3): ...` on isolated BLE blips while the climate/sensor entities keep their previous state. After three consecutive failures the entities become unavailable as before.
* [ ] On healthy setups, behavior is unchanged because the counter never reaches the threshold.

Refs: #281